### PR TITLE
Edit example

### DIFF
--- a/examples/frameworks/huggingface/transformers.ipynb
+++ b/examples/frameworks/huggingface/transformers.ipynb
@@ -141,6 +141,7 @@
     "     per_device_train_batch_size=8,\n",
     "     per_device_eval_batch_size=8,\n",
     "     num_train_epochs=2,\n",
+    "     report_to=["clearml"],\n",    
     ")\n"
    ],
    "metadata": {

--- a/examples/frameworks/huggingface/transformers.ipynb
+++ b/examples/frameworks/huggingface/transformers.ipynb
@@ -141,7 +141,7 @@
     "     per_device_train_batch_size=8,\n",
     "     per_device_eval_batch_size=8,\n",
     "     num_train_epochs=2,\n",
-    "     report_to=["clearml"],\n",    
+    "     report_to=['clearml'],\n",    
     ")\n"
    ],
    "metadata": {


### PR DESCRIPTION
## Related Issue \ discussion
n/a

## Patch Description
transformers trainer by default reports to all supported frameworks, so when ran the notebook, it asked for another platform's credentials. Added to [TrainingArguments](https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.TrainingArguments) `report_to=['clearml']` so it will only report to clearml.  


