### PR TITLE
chore: add py.typed to support PEP 561 type checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,11 @@ setup(
         ]
     },
     package_data={
-        'clearml': ['config/default/*.conf', 'backend_api/config/default/*.conf']
+        "clearml": [
+            "config/default/*.conf",
+            "backend_api/config/default/*.conf",
+            "py.typed",
+        ]
     },
     include_package_data=True,
     # To provide executable scripts, use entry points in preference to the


### PR DESCRIPTION
## Prob Description
This PR addresses the issue with type checking tools (like `mypy`/`pyright`/`basedpyright`) reporting `Stub file not found` errors. The [type coverage analysis using mypy](https://github.com/user-attachments/files/20164431/mypy-report.txt) shows that ClearML's code has good type annotations coverage (especially the backend_api) with an overall coverage of > 88% , making it a good candidate for exposing type information through a `py.typed` marker.

![image](https://github.com/user-attachments/assets/6f5fd0d0-f059-435b-a19a-33c00ce7a188)


## Patch Description
This patch adds a `py.typed` marker file to expose existing type annotations to external tools that comply with [PEP 561](https://peps.python.org/pep-0561/). 

The changes:
1. Add an empty `py.typed` file to the main clearml package directory
2. Updated `setup.py` to include this file in package data

## Testing Instructions
After applying the patch, typing tools like `mypy`, `pyright`, and `basedpyright` should be able to recognize ClearML's type annotations without reporting `Stub file not found` errors.

To test:
1. Build and install the patched version of ClearML
2. Run a type checker like `basedpyright` on code that imports from clearml
3. Verify that "Stub file not found" errors are no longer reported

## Other Information
The presence of a `py.typed` file (as specified in [PEP 561](https://peps.python.org/pep-0561/)) tells type checking tools that the package maintainers intend for the package's type annotations to be used for type checking. This is particularly valuable for users who rely on static type checking in their projects.

@jkhenning @pollfly What do you guys think? Relatively small change with huge QoL improvement.