### PR TITLE
fix: ensure _logger is not None in Session

### DIFF
--- a/clearml/backend_api/session/session.py
+++ b/clearml/backend_api/session/session.py
@@ -154,14 +154,11 @@ class Session(TokenManager):
         self.__class__._sessions_weakrefs.append(weakref.ref(self))
 
         self._verbose = verbose if verbose is not None else ENV_VERBOSE.get()
-        level = (
-            resolve_logging_level(ENV_VERBOSE.get(converter=str))
-            if self._verbose
-            else logging.WARNING
-        )
-        self._logger = logger or get_logger(
-            level=level, stream=sys.stderr if level is logging.DEBUG else None
-        )
+        if logger is not None:
+            self._logger = logger
+        else:
+            level = resolve_logging_level(ENV_VERBOSE.get(converter=str)) if self._verbose else logging.INFO
+            self._logger = get_logger(level=level, stream=sys.stderr if level is logging.DEBUG else None)
         self.__worker = worker or self.get_worker_host_name()
         self.client = ", ".join("{}-{}".format(*x) for x in self._client)
 

--- a/clearml/backend_api/session/session.py
+++ b/clearml/backend_api/session/session.py
@@ -154,10 +154,14 @@ class Session(TokenManager):
         self.__class__._sessions_weakrefs.append(weakref.ref(self))
 
         self._verbose = verbose if verbose is not None else ENV_VERBOSE.get()
-        self._logger = logger
-        if self._verbose and not self._logger:
-            level = resolve_logging_level(ENV_VERBOSE.get(converter=str))
-            self._logger = get_logger(level=level, stream=sys.stderr if level is logging.DEBUG else None)
+        level = (
+            resolve_logging_level(ENV_VERBOSE.get(converter=str))
+            if self._verbose
+            else logging.WARNING
+        )
+        self._logger = logger or get_logger(
+            level=level, stream=sys.stderr if level is logging.DEBUG else None
+        )
         self.__worker = worker or self.get_worker_host_name()
         self.client = ", ".join("{}-{}".format(*x) for x in self._client)
 


### PR DESCRIPTION
This ensures that the module does not crash in case the logger was called when verbosity was not defined. Theold behaviour caused it to crash since `_logger` was `None`, but was still called anyways.



## Patch Description

* Calculates a log level based on `self._verbose` (DEBUG/INFO when `verbose=True`, WARNING otherwise).
* Always assigns a valid logger instance, e.g.:

  ```python
  self._logger = logger or get_logger(
      level=level,
      stream=sys.stderr if level is logging.DEBUG else None,
  )
  ```
* Preserves existing behaviour:

  * No extra output when `verbose=False`.
  * Routes to `stderr` when `verbose=True`.
  * Honours a user‑supplied logger without altering it.
* Fixes an unguarded call in `_do_refresh_token` that would execute:

  ```python
  if not auth and not headers:
      self._logger.warning(
          "refreshing token with no authorization info (no token or credentials, this might fail ... )"
      )
  ```

  which previously crashed when `_logger` was `None`. The above is what caused me to dig into this issue in the first place. The old implementation expects all calls to loggers to check prior to logging, the above is an example where a check was not perfomed. There may be similar code snippets, as above, where a check was forgotten, however this patch takes care of that.

## Steps to reproduce bug in old behaviour
1. Create a minimal `clearml.conf` file:
```HOCON
api {
  credentials {
  "access_key"="sdf"
  "secret_key"=""
  }
}
```
***or***
```HOCON
api {
  credentials {
  "access_key"=""
  "secret_key"="sdf"
  }
}
```
>***NOTE:*** I know that the above is supposed to fail, however I would like it to faile with the proper exception reference, so that as a developer consuming the libarary and building on top of it I should be able to handle the above exception gracefully without having my application crash.

2.  Create a simple script and make sure that the script is referencing the above conf file, and instantiate a `Session`.
```python
from clearml.backend_api import Session
def main():
    Session()
if __name__ == "__main__":
    main()
```
3.  ``AttributeError: 'NoneType' object has no attribute 'warning'``.

## Expected behaviour
Rerun the [above](#steps-to-reproduce-bug-in-old-behaviour), but ensure `verbose=True` when creating your session:
```python
from clearml.backend_api import Session
def main():
    Session(verbose=True)
if __name__ == "__main__":
    main()
```
An exception will be raised, but it will be an "expected exception" `LoginError`, that we can handle in our downstream apps:
```bash
clearml.backend_api.session.session.LoginError: Failed getting token (error 401 from https://api.clear.ml): Unauthorized (missing credentials)
```

## Testing Instructions
Rerun the [above](#Steps-to-reproduce-bug-in-old-behaviour) and ensure that, with the fix applied, that a red warning is emitted instead of a crash, e.g.:

   ```text
   refreshing token with no authorization info (this might fail if session does not have a valid cookie)
   ```
In addition to having the correct exception raised similar to how it was raised when `Sesssion` was initialized with `verbose=True`.


## Other Information

This PR is a small "bandaid" to avoid crashes specifically in the `Session` module; it does not address the broader logging configuration in ClearML. A more robust approach might involve module‑level loggers with `NullHandler` and a central configuration. Happy to open a separate issue to discuss logging strategy if this is of interest. 

@jkhenning @pollfly What do you guys think?
