### PR TITLE
fix: Unhandled None value in project_ids when list all datasets

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -2094,7 +2094,7 @@ class Dataset(object):
             exact_match_regex_flag=False,
             _allow_extra_fields_=True,
         )
-        project_ids = {d.project for d in datasets}
+        project_ids = {d.project for d in datasets if d.project is not None}
         # noinspection PyProtectedMember
         project_id_lookup = Task._get_project_names(list(project_ids))
         return [
@@ -2106,7 +2106,7 @@ class Dataset(object):
                 "tags": d.tags,
                 "version": d.runtime.get("version"),
             }
-            for d in datasets
+            for d in datasets if d.project is not None
         ]
 
     def _add_files(


### PR DESCRIPTION
## Patch Description

When fetching the `project_ids`, some entries can be `None`, even though that should not happen. This causes the program to break. This patch adds defensive checks so that if a `None` value appears for a `project_id`, it is ignored and handled gracefully.

## Old behaviour

Listing all datasets from the CLI or from the SDK could trigger an error due to a `None` being possibly returned as one of the project IDs.

**SDK behaviour**

```python
>>> from clearml import Dataset
>>> Dataset.list_datasets()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    Dataset.list_datasets()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/amerii/projects/.../clearml/datasets/dataset.py", line 1972, in list_datasets
    project_id_lookup = Task._get_project_names(list(project_ids))
  File "/home/amerii/projects/.../clearml/backend_interface/task/task.py", line 2855, in _get_project_names
    projects.GetAllRequest(id=list(project_ids), page=page, page_size=page_size),
    ~~~~~~~~~~~~~~~~~~~~~~~~~^ ...
TypeError: Expected id of type list[(<class 'str'>,)], got NoneType, str
```

**CLI behaviour**

```bash
❯ clearml-data search
clearml-data - Dataset Management & Versioning CLI
Search datasets

Error: Expected id of type list[(<class 'str'>,)], got NoneType, str
```

After investigation, it was clear that `project_id` sometimes returns a `None` value in the set of IDs. The relevant code is here:

[https://github.com/clearml/clearml/blob/4d6b54d51affd2cf4719d00e505ce783e5cf9351/clearml/datasets/dataset.py#L2097-L2110](https://github.com/clearml/clearml/blob/4d6b54d51affd2cf4719d00e505ce783e5cf9351/clearml/datasets/dataset.py#L2097-L2110)

This patch adds checks to skip over any `None` values before proceeding.

## Testing Instructions

1. Apply the patch.
2. Run the following in the Python REPL:

   ```python
   from clearml import Dataset
   Dataset.list_datasets()
   ```
3. Run the CLI command:

   ```bash
   clearml-data search
   ```
4. Verify that both methods complete without errors.

## Other Information

>***Note:*** This change does not address the root cause of `None` values appearing in `project_ids`. A separate issue should track fixing the data source.

@jkhenning 
