### PR TITLE
Fix: StorageManager no longer interferes with root logger (#1405)

### DIFF
--- a/clearml/backend_config/log.py
+++ b/clearml/backend_config/log.py
@@ -41,5 +41,9 @@ def initialize(
         Logger.manager.loggerClass = _Logger
 
     if logging_config is not None:
-        # Use deepcopy since Python's logging infrastructure might modify the dict
-        logging.config.dictConfig(deepcopy(dict(logging_config)))
+        root_logger = logging.getLogger()
+        #added a check to avoid calling dictConfig
+        #if the root user has already set up their own logging.
+        #prevents ClearML from closing their handlers.
+        if not root_logger.handlers:
+            logging.config.dictConfig(deepcopy(dict(logging_config)))

--- a/clearml/debugging/log.py
+++ b/clearml/debugging/log.py
@@ -164,8 +164,10 @@ class LoggerRoot(object):
         loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
         for logger in loggers:
             handlers = getattr(logger, "handlers", [])
-            for handler in handlers:
+            # Iterate over a copy to avoid modifying the list while removing handlers
+            for handler in handlers[:]:
                 if isinstance(handler, ClearmlLoggerHandler):
+                    handler.close()
                     logger.removeHandler(handler)
 
 

--- a/test_storage_manager.py
+++ b/test_storage_manager.py
@@ -1,0 +1,23 @@
+import logging
+from rich.logging import RichHandler
+from clearml.storage.manager import StorageManager
+
+def test_storage_manager_does_not_break_root_logger(tmp_path):
+    log_file = tmp_path / "test.log"
+    local_file = tmp_path / "dummy.txt"
+    local_file.write_text("hello")
+
+    handlers = [
+        RichHandler(rich_tracebacks=True),
+        logging.FileHandler(log_file, mode='w')
+    ]
+    logging.basicConfig(level=logging.INFO, format="%(message)s", handlers=handlers, force=True)
+
+    logging.info("before download")
+    StorageManager.get_local_copy(str(local_file))
+    logging.info("after download")
+
+    with open(log_file) as f:
+        contents = f.read()
+    assert "before download" in contents, "'before download' missing from log file"
+    assert "after download" in contents, "'after download' missing from log file"


### PR DESCRIPTION
Summary
This PR fixes an issue where using StorageManager.get_local_copy() (or any ClearML utility that triggers logging initialization) would close user-defined logging handlers, such as [logging.FileHandler], if the user already configured logging. This caused log messages to stop appearing in user log files after the first ClearML call.

Details
Root cause:
ClearML’s logging initialization called [logging.config.dictConfig], which resets and closes all existing logging handlers, including those set up by the user.
Fix:
The patch adds a check in clearml/backend_config/log.py so that [dictConfig] is only called if the root logger has no handlers. This prevents ClearML from interfering with user logging setups.
I also added a fix that creates a shallow copy in clearml/debugging/log.py in the clear_logger_handlers() function. This function closes the handler before it is removed and modifies the loop to iterate over a shallow copy of the handlers list.
Test:
Added a test (test_storage_manager.py) to ensure that user-defined handlers remain open and receive log messages after calling StorageManager.get_local_copy().
Impact:
Backwards compatible:
If the user does not configure logging, ClearML will still set up logging as before.
Best practice:
This approach follows standard open-source library practices for interacting with Python’s logging system.
Closes: StorageManager affects root logger of logging #1405 (https://github.com/clearml/clearml/issues/1405)