### PR TITLE
Update task.py

### DIFF
--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -2539,6 +2539,10 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
         :param requirements_file: (Optional) Pass a requirements.txt file to specify the required packages (instead of
             ``pip freeze`` or automatic analysis). This will overwrite any existing requirement listing.
         """
+        if not running_remotely() and hasattr(cls, "current_task") and cls.current_task():
+            get_logger("task").warning(
+                "force_requirements_env_freeze ignored, Task.force_requirements_env_freeze() must be called before Task.init()"
+            )
         cls._force_use_pip_freeze = requirements_file if requirements_file else bool(force)
 
     @classmethod
@@ -2551,6 +2555,10 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
 
         :param force: Set force storing the main python file as a single standalone script
         """
+        if not running_remotely() and hasattr(cls, "current_task") and cls.current_task():
+            get_logger("task").warning(
+                "force_store_standalone_script ignored, Task.force_store_standalone_script() must be called before Task.init()"
+            )
         cls._force_store_standalone_script = bool(force)
 
     def _set_random_seed_used(self, random_seed: Optional[int]) -> ():


### PR DESCRIPTION
Adding a warning if force_requirements_env_freeze or force_store_standalone_script are called before Task.Init().

## Related Issue \ discussion
Fixes this issue: https://github.com/clearml/clearml/issues/1425

## Patch Description
Just adds a warning.

## Testing Instructions
N/A

## Other Information
