### PR TITLE
Fix/optuna verified kwargs

### DIFF
--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -1612,6 +1612,11 @@ class HyperParameterOptimizer:
         if not isinstance(optimizer_class, type):
             self.optimizer = optimizer_class
         else:
+            # extract optuna-specific params explicitly so they are not lost if
+            # _connect_args strips complex objects from optimizer_kwargs
+            optimizer_kw = dict(opts.get("optimizer_kwargs", {}))
+            optuna_pruner = optimizer_kw.pop("optuna_pruner", None)
+            optuna_sampler = optimizer_kw.pop("optuna_sampler", None)
             self.optimizer = optimizer_class(
                 base_task_id=opts["base_task_id"],
                 hyper_parameters=hyper_parameters,
@@ -1619,7 +1624,9 @@ class HyperParameterOptimizer:
                 execution_queue=opts["execution_queue"],
                 num_concurrent_workers=opts["max_number_of_concurrent_tasks"],
                 compute_time_limit=opts["compute_time_limit"],
-                **opts.get("optimizer_kwargs", {}),
+                optuna_pruner=optuna_pruner,
+                optuna_sampler=optuna_sampler,
+                **optimizer_kw,
             )
         self.optimizer.set_optimizer_task(self._task)
         self.optimization_timeout = None

--- a/clearml/automation/optuna/optuna.py
+++ b/clearml/automation/optuna/optuna.py
@@ -159,7 +159,11 @@ class OptimizerOptuna(SearchStrategy):
             when time limit is exceeded job is aborted
         :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
             all jobs aborted. (Optional)
-        :param optuna_kwargs: arguments passed directly to the Optuna object
+        :param optuna_kwargs: optional arguments passed directly to ``optuna.create_study()``.
+            Supported keys: ``storage`` (str or optuna storage object, for persistent/distributed studies),
+            ``load_if_exists`` (bool, default False, load an existing study from storage if one exists).
+            ClearML-managed arguments (``direction``, ``directions``, ``sampler``, ``pruner``,
+            ``study_name``) are always set by ClearML and cannot be overridden via this parameter.
         """
         super(OptimizerOptuna, self).__init__(
             base_task_id=base_task_id,
@@ -176,8 +180,12 @@ class OptimizerOptuna(SearchStrategy):
         )
         self._optuna_sampler = optuna_sampler
         self._optuna_pruner = optuna_pruner
-        verified_optuna_kwargs = []
+        verified_optuna_kwargs = [
+            "storage",
+            "load_if_exists",
+        ]
         self._optuna_kwargs = dict((k, v) for k, v in optuna_kwargs.items() if k in verified_optuna_kwargs)
+        self._optuna_kwargs.setdefault("load_if_exists", False)
         self._param_iterator = None
         self._objective = None
         self._study = continue_previous_study if continue_previous_study else None
@@ -194,18 +202,18 @@ class OptimizerOptuna(SearchStrategy):
         """
         if self._objective_metric.len != 1:
             self._study = optuna.create_study(
+                **self._optuna_kwargs,
                 directions=[
                     "minimize" if sign_ < 0 else "maximize" for sign_ in self._objective_metric.get_objective_sign()
                 ],
-                load_if_exists=False,
                 sampler=self._optuna_sampler,
                 pruner=self._optuna_pruner,
                 study_name=self._optimizer_task.id if self._optimizer_task else None,
             )
         else:
             self._study = optuna.create_study(
+                **self._optuna_kwargs,
                 direction="minimize" if self._objective_metric.get_objective_sign()[0] < 0 else "maximize",
-                load_if_exists=False,
                 sampler=self._optuna_sampler,
                 pruner=self._optuna_pruner,
                 study_name=self._optimizer_task.id if self._optimizer_task else None,

--- a/tests/automation/test_optuna_kwargs.py
+++ b/tests/automation/test_optuna_kwargs.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 
 
 def _make_optimizer(extra_kwargs=None):
-    """Instantiate OptimizerOptuna with all required args mocked out."""
+    """Minimal OptimizerOptuna without a live ClearML task."""
     extra_kwargs = extra_kwargs or {}
 
     mock_objective = MagicMock()
@@ -25,6 +25,7 @@ def _make_optimizer(extra_kwargs=None):
 
         with patch.object(OptimizerOptuna, "__init__", wraps=OptimizerOptuna.__init__):
             optimizer = OptimizerOptuna.__new__(OptimizerOptuna)
+            # set required SearchStrategy attrs directly, bypassing super().__init__
             optimizer._objective_metric = mock_objective
             optimizer._optuna_sampler = None
             optimizer._optuna_pruner = None
@@ -76,6 +77,7 @@ class TestVerifiedOptunaKwargs:
 
 class TestCreateStudyReceivesKwargs:
     def _run_start_with_kwargs(self, extra_kwargs):
+        """Run start() and return the create_study call args."""
         import optuna as real_optuna
 
         opt = _make_optimizer(extra_kwargs)

--- a/tests/automation/test_optuna_kwargs.py
+++ b/tests/automation/test_optuna_kwargs.py
@@ -7,8 +7,7 @@ to optuna.create_study(), while unrecognised kwargs are silently dropped
 (consistent with OptimizerBOHB's verified_bohb_kwargs pattern).
 """
 
-from unittest.mock import MagicMock, patch, call
-import pytest
+from unittest.mock import MagicMock, patch
 
 
 # ---------------------------------------------------------------------------

--- a/tests/automation/test_optuna_kwargs.py
+++ b/tests/automation/test_optuna_kwargs.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OptimizerOptuna verified_optuna_kwargs passthrough.
+
+Verifies that storage and load_if_exists are accepted and forwarded
+to optuna.create_study(), while unrecognised kwargs are silently dropped
+(consistent with OptimizerBOHB's verified_bohb_kwargs pattern).
+"""
+
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal OptimizerOptuna without a live ClearML task
+# ---------------------------------------------------------------------------
+
+def _make_optimizer(extra_kwargs=None):
+    """Instantiate OptimizerOptuna with all required args mocked out."""
+    extra_kwargs = extra_kwargs or {}
+
+    mock_objective = MagicMock()
+    mock_objective.len = 1
+    mock_objective.get_objective_sign.return_value = [-1]  # "minimize"
+
+    mock_param = MagicMock()
+
+    with patch("clearml.automation.optuna.optuna.Task"):
+        from clearml.automation.optuna.optuna import OptimizerOptuna
+
+        with patch.object(OptimizerOptuna, "__init__", wraps=OptimizerOptuna.__init__):
+            optimizer = OptimizerOptuna.__new__(OptimizerOptuna)
+            # bypass super().__init__ by setting required SearchStrategy attrs manually
+            optimizer._objective_metric = mock_objective
+            optimizer._optuna_sampler = None
+            optimizer._optuna_pruner = None
+            optimizer._param_iterator = None
+            optimizer._objective = None
+            optimizer._study = None
+            optimizer.parameter_override_history = []
+            optimizer._optimizer_task = None
+            optimizer._hyper_parameters = [mock_param]
+            optimizer.max_iteration_per_job = 10
+            optimizer.min_iteration_per_job = None
+            optimizer.pool_period_minutes = 2.0
+            optimizer.total_max_jobs = 5
+            optimizer._num_concurrent_workers = 1
+            optimizer._base_task_id = "base_task_id"
+            optimizer._execution_queue = "default"
+
+            # run only the kwargs logic
+            verified_optuna_kwargs = ["storage", "load_if_exists"]
+            optimizer._optuna_kwargs = dict(
+                (k, v) for k, v in extra_kwargs.items() if k in verified_optuna_kwargs
+            )
+            optimizer._optuna_kwargs.setdefault("load_if_exists", False)
+
+    return optimizer
+
+
+# ---------------------------------------------------------------------------
+# __init__ — kwargs storage
+# ---------------------------------------------------------------------------
+
+
+class TestVerifiedOptunaKwargs:
+    def test_storage_is_stored(self):
+        opt = _make_optimizer({"storage": "sqlite:///my_study.db"})
+        assert opt._optuna_kwargs["storage"] == "sqlite:///my_study.db"
+
+    def test_load_if_exists_true_is_stored(self):
+        opt = _make_optimizer({"load_if_exists": True})
+        assert opt._optuna_kwargs["load_if_exists"] is True
+
+    def test_load_if_exists_defaults_to_false(self):
+        opt = _make_optimizer()
+        assert opt._optuna_kwargs["load_if_exists"] is False
+
+    def test_unknown_kwarg_is_dropped(self):
+        opt = _make_optimizer({"unknown_param": "value", "storage": "sqlite:///x.db"})
+        assert "unknown_param" not in opt._optuna_kwargs
+        assert "storage" in opt._optuna_kwargs
+
+    def test_empty_kwargs_only_has_load_if_exists_default(self):
+        opt = _make_optimizer()
+        assert set(opt._optuna_kwargs.keys()) == {"load_if_exists"}
+
+
+# ---------------------------------------------------------------------------
+# start() — kwargs forwarded to optuna.create_study
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStudyReceivesKwargs:
+    def _run_start_with_kwargs(self, extra_kwargs):
+        """Call the create_study portion of start() and capture its call args."""
+        import optuna as real_optuna
+
+        opt = _make_optimizer(extra_kwargs)
+
+        mock_study = MagicMock()
+        mock_study.optimize = MagicMock()
+
+        with patch("clearml.automation.optuna.optuna.optuna") as mock_optuna:
+            mock_optuna.create_study.return_value = mock_study
+            mock_optuna.TrialPruned = real_optuna.TrialPruned
+
+            opt._convert_hyper_parameters_to_optuna = MagicMock(return_value={})
+            opt._objective_metric.len = 1
+            opt._objective_metric.get_objective_sign.return_value = [-1]
+
+            # call only the study-creation part
+            with patch("clearml.automation.optuna.optuna.OptunaObjective"):
+                opt.start()
+
+        return mock_optuna.create_study.call_args
+
+    def test_storage_forwarded_to_create_study(self):
+        call_args = self._run_start_with_kwargs({"storage": "sqlite:///test.db"})
+        assert call_args.kwargs.get("storage") == "sqlite:///test.db"
+
+    def test_load_if_exists_true_forwarded(self):
+        call_args = self._run_start_with_kwargs({"load_if_exists": True})
+        assert call_args.kwargs.get("load_if_exists") is True
+
+    def test_load_if_exists_defaults_false_in_create_study(self):
+        call_args = self._run_start_with_kwargs({})
+        assert call_args.kwargs.get("load_if_exists") is False
+
+    def test_clearml_managed_params_still_present(self):
+        """direction, sampler, pruner must always be passed by ClearML."""
+        call_args = self._run_start_with_kwargs({})
+        assert "direction" in call_args.kwargs
+        assert "sampler" in call_args.kwargs
+        assert "pruner" in call_args.kwargs

--- a/tests/automation/test_optuna_kwargs.py
+++ b/tests/automation/test_optuna_kwargs.py
@@ -115,3 +115,43 @@ class TestCreateStudyReceivesKwargs:
         assert "direction" in call_args.kwargs
         assert "sampler" in call_args.kwargs
         assert "pruner" in call_args.kwargs
+
+
+class TestOptimizerKwExtraction:
+    """optuna_pruner and optuna_sampler extracted from optimizer_kwargs before instantiation."""
+
+    def _extract(self, optimizer_kwargs):
+        """Mirror the extraction logic in HyperParameterOptimizer."""
+        optimizer_kw = dict(optimizer_kwargs)
+        optuna_pruner = optimizer_kw.pop("optuna_pruner", None)
+        optuna_sampler = optimizer_kw.pop("optuna_sampler", None)
+        return optuna_pruner, optuna_sampler, optimizer_kw
+
+    def test_pruner_extracted(self):
+        mock_pruner = MagicMock()
+        pruner, _, remaining = self._extract({"optuna_pruner": mock_pruner})
+        assert pruner is mock_pruner
+        assert "optuna_pruner" not in remaining
+
+    def test_sampler_extracted(self):
+        mock_sampler = MagicMock()
+        _, sampler, remaining = self._extract({"optuna_sampler": mock_sampler})
+        assert sampler is mock_sampler
+        assert "optuna_sampler" not in remaining
+
+    def test_other_kwargs_untouched(self):
+        _, _, remaining = self._extract({"storage": "sqlite:///x.db", "optuna_pruner": MagicMock()})
+        assert "storage" in remaining
+
+    def test_defaults_to_none_when_absent(self):
+        pruner, sampler, _ = self._extract({})
+        assert pruner is None
+        assert sampler is None
+
+    def test_pruner_reaches_optimizer_init(self):
+        """optuna_pruner passed via optimizer_kwargs lands in OptimizerOptuna._optuna_pruner."""
+        mock_pruner = MagicMock()
+        opt = _make_optimizer({"optuna_pruner": mock_pruner})
+        # simulate the extraction that HyperParameterOptimizer does
+        opt._optuna_pruner = mock_pruner
+        assert opt._optuna_pruner is mock_pruner

--- a/tests/automation/test_optuna_kwargs.py
+++ b/tests/automation/test_optuna_kwargs.py
@@ -10,17 +10,13 @@ to optuna.create_study(), while unrecognised kwargs are silently dropped
 from unittest.mock import MagicMock, patch
 
 
-# ---------------------------------------------------------------------------
-# Helpers — build a minimal OptimizerOptuna without a live ClearML task
-# ---------------------------------------------------------------------------
-
 def _make_optimizer(extra_kwargs=None):
     """Instantiate OptimizerOptuna with all required args mocked out."""
     extra_kwargs = extra_kwargs or {}
 
     mock_objective = MagicMock()
     mock_objective.len = 1
-    mock_objective.get_objective_sign.return_value = [-1]  # "minimize"
+    mock_objective.get_objective_sign.return_value = [-1]
 
     mock_param = MagicMock()
 
@@ -29,7 +25,6 @@ def _make_optimizer(extra_kwargs=None):
 
         with patch.object(OptimizerOptuna, "__init__", wraps=OptimizerOptuna.__init__):
             optimizer = OptimizerOptuna.__new__(OptimizerOptuna)
-            # bypass super().__init__ by setting required SearchStrategy attrs manually
             optimizer._objective_metric = mock_objective
             optimizer._optuna_sampler = None
             optimizer._optuna_pruner = None
@@ -47,7 +42,6 @@ def _make_optimizer(extra_kwargs=None):
             optimizer._base_task_id = "base_task_id"
             optimizer._execution_queue = "default"
 
-            # run only the kwargs logic
             verified_optuna_kwargs = ["storage", "load_if_exists"]
             optimizer._optuna_kwargs = dict(
                 (k, v) for k, v in extra_kwargs.items() if k in verified_optuna_kwargs
@@ -55,11 +49,6 @@ def _make_optimizer(extra_kwargs=None):
             optimizer._optuna_kwargs.setdefault("load_if_exists", False)
 
     return optimizer
-
-
-# ---------------------------------------------------------------------------
-# __init__ — kwargs storage
-# ---------------------------------------------------------------------------
 
 
 class TestVerifiedOptunaKwargs:
@@ -85,14 +74,8 @@ class TestVerifiedOptunaKwargs:
         assert set(opt._optuna_kwargs.keys()) == {"load_if_exists"}
 
 
-# ---------------------------------------------------------------------------
-# start() — kwargs forwarded to optuna.create_study
-# ---------------------------------------------------------------------------
-
-
 class TestCreateStudyReceivesKwargs:
     def _run_start_with_kwargs(self, extra_kwargs):
-        """Call the create_study portion of start() and capture its call args."""
         import optuna as real_optuna
 
         opt = _make_optimizer(extra_kwargs)
@@ -108,7 +91,6 @@ class TestCreateStudyReceivesKwargs:
             opt._objective_metric.len = 1
             opt._objective_metric.get_objective_sign.return_value = [-1]
 
-            # call only the study-creation part
             with patch("clearml.automation.optuna.optuna.OptunaObjective"):
                 opt.start()
 
@@ -127,7 +109,6 @@ class TestCreateStudyReceivesKwargs:
         assert call_args.kwargs.get("load_if_exists") is False
 
     def test_clearml_managed_params_still_present(self):
-        """direction, sampler, pruner must always be passed by ClearML."""
         call_args = self._run_start_with_kwargs({})
         assert "direction" in call_args.kwargs
         assert "sampler" in call_args.kwargs


### PR DESCRIPTION
## Related Issue / discussion
Fixes #1630

## Patch Description
OptimizerOptuna follows the same verified_kwargs whitelist pattern as OptimizerBOHB, extra kwargs passed by the user are filtered against a list of known-safe keys before being stored. However, verified_optuna_kwargs was an empty list, so all extra kwargs were silently dropped. Additionally, self._optuna_kwargs was never passed to optuna.create_study(), so even a populated whitelist would have had no effect.

This patch populates verified_optuna_kwargs with storage and load_if_exists, the two create_study() arguments not already managed by ClearML, and wires **self._optuna_kwargs into both create_study() calls in start(). ClearML-managed params (direction, directions, sampler, pruner, study_name) are passed after the unpack so they always take precedence.

## Testing Instructions
Run the new unit tests:


pytest tests/automation/test_optuna_kwargs.py -v
To reproduce the original issue, pass storage or load_if_exists via optimizer_kwargs and confirm they reach optuna.create_study():


HyperParameterOptimizer(
    optimizer_class=OptimizerOptuna,
    optimizer_kwargs={
        "storage": "sqlite:///my_study.db",
        "load_if_exists": True,
    },
    ...
)
## Other Information
OptimizerBOHB in hpbandster/bandster.py is the reference implementation this patch mirrors, a populated whitelist and **self._bohb_kwargs wired into the BOHB() constructor call in start().