### PR TITLE
Add hyperdataset method to get an iterator for it

### DIFF
--- a/clearml/hyperdatasets/data_view.py
+++ b/clearml/hyperdatasets/data_view.py
@@ -292,6 +292,9 @@ class DataView:
         self._tags = tags
         self._project_name = project_name
         self._id = None
+        # Internal: when False, iteration never auto-stores this DataView on the server
+        # (reads go through the inline frames endpoints, which require no stored id)
+        self._store_on_iteration = True
         self._filter_rules: List[Any] = []
         self._labels_enumeration: Optional[dict] = None  # Dict[str, int]
         self._mapping_rules: List[Any] = []  # List[dataviews.MappingRule]
@@ -932,6 +935,8 @@ class DataView:
                 pass
             if not running_remotely():
                 return
+        if not getattr(self, "_store_on_iteration", True):
+            return
         if not bool(self._store_dataviews_on_creation):
             return
         try:
@@ -1396,6 +1401,8 @@ class DataView:
             """
             Fetch the next data-entry object, respecting synthetic epoch limits.
             """
+            if not self._started:
+                self.__iter__()
             if self._limit is not None and self._yielded >= self._limit:
                 self._stop_event.set()
                 self._closed = True

--- a/clearml/hyperdatasets/management.py
+++ b/clearml/hyperdatasets/management.py
@@ -1,3 +1,4 @@
+import logging
 from typing import (
     Optional,
     Sequence,
@@ -363,4 +364,54 @@ class HyperDatasetManagement:
         return HyperDatasetManagementBackend.get_version_metadata(
             dataset_id=self._dataset_id,
             version_id=self._version_id,
+        )
+
+    def get_iterator(
+        self,
+        projection: Optional[Sequence[str]] = None,
+        batch_size: Optional[int] = None,
+    ):
+        """
+        Return an iterator over all the data entries (frames) of the bound dataset version.
+
+        This is a convenience wrapper around a single-query `DataView` pinned to this
+        version: entries stream through the same iteration pipeline as DataView
+        iteration (background prefetching, entry-class conversion), but no DataView
+        object is persisted on the server and no Task is attached.
+
+        For filtered, weighted, or multi-version iteration, build a `DataView` instead.
+
+        :param projection: Optional list of frame fields to return, using dot-separated
+            notation (for example ``["id", "sources"]``). When set, entries are
+            reconstructed from the projected fields only — non-projected fields are
+            missing from the returned objects
+        :param batch_size: Optional number of entries fetched per backend request
+
+        :return: Iterator yielding `DataEntry`-derived objects
+        """
+        if not getattr(self, "_version_id", None) or not getattr(self, "_dataset_id", None):
+            raise ValueError("HyperDataset instance is not bound to a dataset version")
+
+        version = HyperDatasetManagementBackend.get_version_by_id(
+            dataset_id=self._dataset_id,
+            version_id=self._version_id,
+            only_fields=["id", "status"],
+        )
+        if version is None:
+            raise ValueError(f"Version not found: {self._version_id} (dataset={self._dataset_id})")
+        if str(getattr(version, "status", None) or "") != "published":
+            logging.getLogger("HyperDataset").warning(
+                "Iterating over a non-published dataset version %s", self._version_id
+            )
+
+        # Local import to avoid a circular dependency (data_view imports this module)
+        from .data_view import DataView
+
+        dataview = DataView(auto_connect_with_task=False)
+        # Version iteration must not litter the server with anonymous DataView objects
+        dataview._store_on_iteration = False
+        dataview.add_query(dataset_id=self._dataset_id, version_id=self._version_id)
+        return dataview.get_iterator(
+            projection=projection,
+            **({"query_cache_size": int(batch_size)} if batch_size else {}),
         )


### PR DESCRIPTION
## Patch Description
This PR adds a method on the `HyperDataset` class to allow dynamically getting a dataview `Iterator` to iterate over it.