### PR TITLE
Fix nondeterministic type validation messages

### DIFF
--- a/clearml/backend_api/session/datamodel.py
+++ b/clearml/backend_api/session/datamodel.py
@@ -123,7 +123,7 @@ class DataModel:
         if not all(isinstance(x, expected) for x in value):
             raise TypeError(
                 f"Expected {field_name} of type list[{expected}], "
-                f"got {', '.join(set(type(x).__name__ for x in value))}"
+                f"got {', '.join(sorted(set(type(x).__name__ for x in value)))}"
             )
 
     @staticmethod


### PR DESCRIPTION
## Related Issue \ discussion
Fixes #1692<br/>

## Patch Description
This sorts the deduplicated type names in `DataModel.assert_isinstance(..., is_array=True)` before including them in the raised `TypeError`.

The current set iteration order can depend on Python's per-process hash seed, so the same mixed invalid collection may produce different validation text across interpreter runs. Sorting keeps the message deterministic without changing which types are reported, or affecting successful validation.<br/>

## Testing Instructions
* Run the helper with the same mixed invalid value under 16 `PYTHONHASHSEED` values. The previous expression produced all six possible orderings of three type names; this change produces one stable message.
* The modified file passes ClearML's documented Flake8 configuration:

  ```console
  flake8 --max-line-length=120 --statistics --show-source --extend-ignore=E501 clearml/backend_api/session/datamodel.py
  ```
* The documented repository-wide Flake8 command reports the same 46 pre-existing `E203` findings on this branch and on untouched `master`; none are in the modified file.

## Other Information
This changes only the ordering of type names in an already-failing validation path.