### PR TITLE
gh-1697: fix Version crash on PEP 440 local versions (e.g. torch 2.1.0+cu121)

### DIFF
--- a/clearml/utilities/version.py
+++ b/clearml/utilities/version.py
@@ -311,7 +311,7 @@ class Version(_BaseVersion):
 
         if not local:
             # Versions without a local segment should sort before those with one.
-            local = inf
+            local = ()
         else:
             # Versions with a local segment need that segment parsed to implement
             # the sorting rules in PEP440.
@@ -320,6 +320,6 @@ class Version(_BaseVersion):
             # - Numeric segments sort numerically
             # - Shorter versions sort before longer versions when the prefixes
             #   match exactly
-            local = local[1]
+            local = tuple((i, "") if isinstance(i, int) else (-inf, i) for i in local)
 
         return epoch, release, pre, post, dev, local

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,19 @@
+from clearml.utilities.version import Version
+
+
+def test_local_version_segment_does_not_crash():
+    # PEP 440 local versions such as PyTorch's "2.1.0+cu121" are valid and must
+    # be parseable. _cmpkey's local handling used to raise IndexError on any
+    # single-segment local version, even though is_valid_version_string accepts
+    # it.
+    for spec in ("2.1.0+cu121", "1.0+cpu", "2.0.1+cu118"):
+        assert Version.is_valid_version_string(spec)
+        assert Version(spec).local == spec.split("+", 1)[1]
+
+
+def test_local_version_ordering():
+    # Absent local sorts before a present one; within a local segment,
+    # alphanumeric parts sort before numeric parts (PEP 440).
+    assert Version("2.1.0+cu118") < Version("2.1.0+cu121")
+    assert Version("1.0") < Version("1.0+abc")
+    assert Version("1.0+abc") < Version("1.0+1")


### PR DESCRIPTION
Fixes #1697.

## What

`clearml.utilities.version.Version` raises `IndexError: tuple index out of range` when constructing a valid PEP 440 version that has a **local segment** — e.g. PyTorch's CUDA/CPU wheels (`2.1.0+cu121`, `1.0+cpu`, `2.0.1+cu118`), which are ubiquitous in the ML environments ClearML instruments.

```python
from clearml.utilities.version import Version
Version.is_valid_version_string("2.1.0+cu121")  # True
Version("2.1.0+cu121")                           # IndexError: tuple index out of range
```

The parser validates the string as legal but crashes when constructing it.

## Why

In `Version._cmpkey` the local segment was reduced with `local = local[1]`, but `_parse_local_version` returns the local segment as a **tuple** — `"cu121"` → `("cu121",)` — which has no index `1`. So single-segment local versions (the common case) crash, and multi-segment ones silently keep only the 2nd element (wrong ordering). The old no-local branch also set `local = inf`, which contradicts the code's own comment that absent locals should sort *before* present ones.

## How

Parse the local segment the way `packaging.version` does:

```diff
         if not local:
-            local = inf
+            local = ()
         else:
-            local = local[1]
+            local = tuple((i, "") if isinstance(i, int) else (-inf, i) for i in local)
```

- Absent local → empty tuple, which sorts before any present local (matching the comment).
- Present local → tuple of pairs, so alphanumeric parts sort before numeric parts and shorter prefixes sort first.

Verified against `packaging.version.Version`: **zero ordering mismatches** across a mixed set of local / pre-release / release versions, and `2.1.0+cu118 < 2.1.0+cu121`, `1.0 < 1.0+abc`, `1.0+abc < 1.0+1` all hold.

## Tests

Adds `tests/test_version.py` covering the crash (`2.1.0+cu121`, `1.0+cpu`, `2.0.1+cu118`) and the ordering rules. Both tests **fail on `master`** (`IndexError`) and pass with this change. `flake8 --max-line-length=120 --extend-ignore=E501` is clean.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*