### PR TITLE
Fix pipeline timeout handling before task start

### DIFF
--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -3408,7 +3408,12 @@ class PipelineController:
                         nodes_failed_stop_pipeline.append(node.name)
                 elif node.timeout:
                     started = node.job.task.data.started
-                    if (datetime.now().astimezone(started.tzinfo) - started).total_seconds() > node.timeout:
+                    if started is None:
+                        node.job.task.reload()
+                        started = node.job.task.data.started
+                    if started is not None and (
+                        datetime.now().astimezone(started.tzinfo) - started
+                    ).total_seconds() > node.timeout:
                         node.job.abort()
                         completed_jobs.append(j)
                         node.executed = node.job.task_id()
@@ -4210,7 +4215,12 @@ class PipelineDecorator(PipelineController):
                         nodes_failed_stop_pipeline.append(node.name)
                 elif node.timeout:
                     started = node.job.task.data.started
-                    if (datetime.now().astimezone(started.tzinfo) - started).total_seconds() > node.timeout:
+                    if started is None:
+                        node.job.task.reload()
+                        started = node.job.task.data.started
+                    if started is not None and (
+                        datetime.now().astimezone(started.tzinfo) - started
+                    ).total_seconds() > node.timeout:
                         node.job.abort()
                         completed_jobs.append(j)
                         node.executed = node.job.task_id()


### PR DESCRIPTION
## Summary

- prevent the pipeline daemon from accessing `started.tzinfo` when a task has not started yet
- reload task data when `task.data.started` is `None`
- skip the timeout calculation if the task is still queued after the reload
- apply the same handling to both `PipelineController` and `PipelineDecorator`

## Problem

A pipeline step with a `time_limit` can still be queued when the daemon evaluates its timeout.

In that case, `node.job.task.data.started` can be `None`, and accessing `started.tzinfo` raises an `AttributeError`, terminating the daemon thread.

## Fix

When `started` is `None`, reload the task data and check the value again. The timeout calculation is only performed once a valid start timestamp is available.

This preserves the existing timeout behavior for running tasks while allowing queued tasks to continue being monitored safely.

## Verification

- `git diff --check`
- `python -m py_compile clearml/automation/controller.py`
- `flake8` on `clearml/automation/controller.py`
- reproduced the original `NoneType.tzinfo` failure before the change
- verified that a task with `started=None` reloads and the daemon continues safely after the change

Fixes #1640
