### PR TITLE
Python 2 deprecation: `six.python_2_unicode_compatible`

### DIFF
--- a/clearml/automation/aws_driver.py
+++ b/clearml/automation/aws_driver.py
@@ -6,8 +6,7 @@ from attr.validators import instance_of
 
 from .. import Task
 from ..utilities.pyhocon import ConfigFactory, ConfigTree
-from .auto_scaler import CloudDriver
-from .cloud_driver import parse_tags
+from .cloud_driver import CloudDriver, parse_tags
 
 try:
     # noinspection PyPackageRequirements

--- a/clearml/automation/bash_script_template.py
+++ b/clearml/automation/bash_script_template.py
@@ -1,0 +1,135 @@
+import shlex
+from typing import Optional
+
+# Placeholders in this template fall into exactly two categories, and the difference is what
+# keeps the rendered script injection-free:
+#
+#   * Shell *data* -- {clearml_conf}, {api_server}, {web_server}, {files_server},
+#     {worker_prefix}, {access_key}, {secret_key}, {auth_token}, {queue}, and the image inside
+#     {docker}. These carry configuration- and API-supplied text, so
+#     `render_bash_script_template` passes each through `shlex.quote` (and neutralises the
+#     heredoc body with a quoted delimiter) as it fills the template. The template deliberately
+#     holds no quotes of its own around them: `shlex.quote` already emits a complete shell
+#     token, and wrapping that token in more quotes would re-open the hole it closes.
+#
+#   * Shell *code* -- {instance_id_command}, {bash_script} and {driver_extra}. These are
+#     command fragments that exist to be executed, so they are inserted verbatim. Whoever
+#     hands them to this module is responsible for quoting the values they embed.
+#
+# A new placeholder belongs to the first category unless it is genuinely a command.
+bash_script_template = """\
+#!/bin/bash
+
+set -x
+
+apt-get update
+apt-get install -y \
+        build-essential \
+        gcc \
+        git \
+        python3-dev \
+        python3-pip
+python3 -m pip install -U pip
+python3 -m pip install virtualenv
+python3 -m virtualenv clearml_agent_venv
+source clearml_agent_venv/bin/activate
+python -m pip install clearml-agent
+cat << '{clearml_conf_delimiter}' >> ~/clearml.conf
+{clearml_conf}
+{clearml_conf_delimiter}
+export CLEARML_API_HOST={api_server}
+export CLEARML_WEB_HOST={web_server}
+export CLEARML_FILES_HOST={files_server}
+export DYNAMIC_INSTANCE_ID=$({instance_id_command})
+export CLEARML_WORKER_ID={worker_prefix}:$DYNAMIC_INSTANCE_ID
+export CLEARML_API_ACCESS_KEY={access_key}
+export CLEARML_API_SECRET_KEY={secret_key}
+export CLEARML_AUTH_TOKEN={auth_token}
+source ~/.bashrc
+{bash_script}
+{driver_extra}
+python -m clearml_agent --config-file ~/clearml.conf daemon --queue {queue} {docker}
+
+if [[ $? -ne 0 ]]
+then
+  exit 1
+fi
+
+shutdown
+"""
+
+default_clearml_conf_delimiter = "CLEARML_CONF_EOF"
+
+
+def render_bash_script_template(
+    queue_name: str,
+    worker_prefix: str,
+    auth_token: Optional[str],
+    access_key: Optional[str],
+    api_server: str,
+    clearml_conf: str,
+    files_server: str,
+    secret_key: Optional[str],
+    web_server: str,
+    extra_vm_bash_script: str,
+    cpu_only: bool,
+    driver_extra: str,
+    docker_image: Optional[str],
+    instance_id_command: str,
+) -> str:
+    """
+    Render the bash script a freshly provisioned instance runs to join a queue as an agent.
+
+    Every argument naming shell data is quoted as the template is filled, so no value can end a
+    quote, open a command substitution, or close the configuration heredoc and have the lines
+    behind it run as commands. The two arguments naming shell code --
+    ``extra_vm_bash_script`` and ``driver_extra`` -- plus ``instance_id_command`` are inserted
+    verbatim and must arrive already quoted.
+
+    :param str queue_name: clearml queue the spun-up agent listens to.
+    :param str worker_prefix: Worker name the instance id is appended to.
+    :param Optional[str] auth_token: clearml authentication token; absent when key/secret are used instead.
+    :param Optional[str] access_key: clearml API access key; absent when a token is used instead.
+    :param str api_server: clearml API server URL.
+    :param str clearml_conf: Body of the ``clearml.conf`` written on the instance.
+    :param str files_server: clearml file server URL.
+    :param Optional[str] secret_key: clearml API secret key; absent when a token is used instead.
+    :param str web_server: clearml web server URL.
+    :param str extra_vm_bash_script: Operator-supplied shell code to run before the agent starts.
+    :param bool cpu_only: Hide the instance's GPUs from the agent.
+    :param str driver_extra: Driver-supplied shell code to run before the agent starts.
+    :param Optional[str] docker_image: Image the agent runs tasks in; absent to run without docker.
+    :param str instance_id_command: Shell command printing the instance id.
+    :returns: The bash script to hand the instance as its user data.
+    :rtype: str
+    """
+    # Lengthen the delimiter until no configuration line can close the heredoc early.
+    clearml_conf_delimiter = default_clearml_conf_delimiter
+    clearml_conf_lines = frozenset(line.strip() for line in clearml_conf.splitlines())
+    while clearml_conf_delimiter in clearml_conf_lines:
+        clearml_conf_delimiter += "_"
+
+    return bash_script_template.format(
+        queue=shlex.quote(queue_name),
+        worker_prefix=shlex.quote(worker_prefix),
+        auth_token=shlex.quote(auth_token or ""),
+        access_key=shlex.quote(access_key or ""),
+        api_server=shlex.quote(api_server),
+        clearml_conf=clearml_conf,
+        clearml_conf_delimiter=clearml_conf_delimiter,
+        files_server=shlex.quote(files_server),
+        secret_key=shlex.quote(secret_key or ""),
+        web_server=shlex.quote(web_server),
+        bash_script=(
+            f"export NVIDIA_VISIBLE_DEVICES=none; {extra_vm_bash_script}"  # ruff-format-hint
+            if cpu_only
+            else extra_vm_bash_script
+        ),
+        driver_extra=driver_extra,
+        docker=(
+            f"--docker {shlex.quote(docker_image)}"  # ruff-format-hint
+            if docker_image
+            else ""
+        ),
+        instance_id_command=instance_id_command,
+    )

--- a/clearml/automation/cloud_driver.py
+++ b/clearml/automation/cloud_driver.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 from abc import ABC, abstractmethod
 import os
 from typing import List, Tuple, Any
@@ -7,50 +8,10 @@ import attr
 
 from ..backend_api import Session
 from ..backend_api.session.defs import ENV_AUTH_TOKEN
+from .bash_script_template import render_bash_script_template
 
 env_git_user = "CLEARML_AUTOSCALER_GIT_USER"
 env_git_pass = "CLEARML_AUTOSCALER_GIT_PASSWORD"
-
-bash_script_template = """\
-#!/bin/bash
-
-set -x
-
-apt-get update
-apt-get install -y \
-        build-essential \
-        gcc \
-        git \
-        python3-dev \
-        python3-pip
-python3 -m pip install -U pip
-python3 -m pip install virtualenv
-python3 -m virtualenv clearml_agent_venv
-source clearml_agent_venv/bin/activate
-python -m pip install clearml-agent
-cat << EOF >> ~/clearml.conf
-{clearml_conf}
-EOF
-export CLEARML_API_HOST={api_server}
-export CLEARML_WEB_HOST={web_server}
-export CLEARML_FILES_HOST={files_server}
-export DYNAMIC_INSTANCE_ID=$({instance_id_command})
-export CLEARML_WORKER_ID={worker_prefix}:$DYNAMIC_INSTANCE_ID
-export CLEARML_API_ACCESS_KEY='{access_key}'
-export CLEARML_API_SECRET_KEY='{secret_key}'
-export CLEARML_AUTH_TOKEN='{auth_token}'
-source ~/.bashrc
-{bash_script}
-{driver_extra}
-python -m clearml_agent --config-file ~/clearml.conf daemon --queue '{queue}' {docker}
-
-if [[ $? -ne 0 ]]
-then
-  exit 1
-fi
-
-shutdown
-"""
 
 clearml_conf_template = """\
 agent.git_user="{git_user}"
@@ -135,27 +96,20 @@ class CloudDriver(ABC):
         task_id: str,
         cpu_only: bool = False,
     ) -> str:
-        return bash_script_template.format(
-            queue=queue_name,
+        return render_bash_script_template(
+            queue_name=queue_name,
             worker_prefix=worker_prefix,
-            auth_token=self.auth_token or "",
-            access_key=self.access_key or "",
+            auth_token=self.auth_token,
+            access_key=self.access_key,
             api_server=self.api_server,
             clearml_conf=self.clearml_conf(),
             files_server=self.files_server,
-            secret_key=self.secret_key or "",
+            secret_key=self.secret_key,
             web_server=self.web_server,
-            bash_script=(
-                f"export NVIDIA_VISIBLE_DEVICES=none; {self.extra_vm_bash_script}"  # ruff-format-hint
-                if cpu_only
-                else self.extra_vm_bash_script
-            ),
+            extra_vm_bash_script=self.extra_vm_bash_script,
+            cpu_only=cpu_only,
             driver_extra=self.driver_bash_extra(task_id),
-            docker=(
-                f"--docker '{self.docker_image}'"  # ruff-format-hint
-                if self.docker_image
-                else ""
-            ),
+            docker_image=self.docker_image,
             instance_id_command=self.instance_id_command(),
         )
 
@@ -179,7 +133,7 @@ class CloudDriver(ABC):
 
     def driver_bash_extra(self, task_id: str) -> str:
         return (
-            f"python -m clearml_agent --config-file ~/clearml.conf execute --id {task_id}"
+            f"python -m clearml_agent --config-file ~/clearml.conf execute --id {shlex.quote(task_id)}"
             if task_id  # ruff-format-hint
             else ""
         )

--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -1620,7 +1620,7 @@ class PipelineController:
         :param project_name: Set the project name for the pipeline.
         :param task_name: Set the name of the remote pipeline.
         :param repo: Remote URL for the repository to use, or path to local copy of the git repository.
-            Example: ``'https://github.com/allegroai/clearml.git'`` or ``'~/project/repo'``. If ``repo`` is specified, then
+            Example: ``'https://github.com/clearml/clearml.git'`` or ``'~/project/repo'``. If ``repo`` is specified, then
             the ``script`` parameter must also be specified.
         :param branch: Select specific repository branch/tag (implies the latest commit from the branch).
         :param commit: Select specific commit ID to use (default: latest commit,

--- a/clearml/automation/hpbandster/bandster.py
+++ b/clearml/automation/hpbandster/bandster.py
@@ -179,7 +179,7 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
         **bohb_kwargs: Any,
     ) -> None:
         """
-        Initialize a BOHB search strategy optimizer
+        Initialize a BOHB search strategy optimizer.
         BOHB performs robust and efficient hyperparameter optimization at scale by combining
         the speed of Hyperband searches with the guidance and guarantees of convergence of Bayesian
         Optimization. Instead of sampling new configurations at random,
@@ -197,30 +197,31 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
             }
 
 
-        :param str base_task_id: Task ID (str)
-        :param list hyper_parameters: list of Parameter objects to optimize over
-        :param Objective objective_metric: Objective metric to maximize / minimize
-        :param str execution_queue: execution queue to use for launching Tasks (experiments).
-        :param int num_concurrent_workers: Limit number of concurrent running Tasks (machines)
-        :param int min_iteration_per_job: minimum number of iterations for a job to run.
-            'iterations' are the reported iterations for the specified objective,
+        :param base_task_id: Task ID to be used as a template task to optimize.
+        :param hyper_parameters: List of Parameter objects to optimize over.
+        :param objective_metric: Objective metric to maximize / minimize.
+        :param execution_queue: Execution queue to use for launching Tasks (experiments).
+        :param num_concurrent_workers: Maximum number of concurrent running Tasks (machines).
+        :param min_iteration_per_job: Minimum number of iterations for a job to run.
+            ``iterations`` are the reported iterations for the specified objective,
             not the maximum reported iteration of the Task.
-        :param int max_iteration_per_job: number of iteration per job
-            'iterations' are the reported iterations for the specified objective,
+        :param max_iteration_per_job: Maximum number of iterations per job.
+            ``iterations`` are the reported iterations for the specified objective,
             not the maximum reported iteration of the Task.
-        :param int total_max_jobs: total maximum job for the optimization process.
-            Must be provided in order to calculate the total budget for the optimization process.
-            The total budget is measured by "iterations" (see above)
-            and will be set to `max_iteration_per_job * total_max_jobs`
-            This means more than total_max_jobs could be created, as long as the cumulative iterations
-            (summed over all created jobs) will not exceed `max_iteration_per_job * total_max_jobs`
-        :param float pool_period_min: time in minutes between two consecutive pools
-        :param float time_limit_per_job: Optional, maximum execution time per single job in minutes,
-            when time limit is exceeded job is aborted
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param int local_port: default port 9090 tcp, this is a must for the BOHB workers to communicate, even locally.
-        :param bohb_kwargs: arguments passed directly to the BOHB object
+        :param total_max_jobs: Total maximum jobs for the optimization process.
+            Must be provided in order to calculate the total budget for the optimization process
+            The total budget is measured in ``iterations`` (see above)
+            and will be set to ``max_iteration_per_job * total_max_jobs``.
+            This means more than ``total_max_jobs`` could be created, as long as the cumulative iterations
+            (summed over all created jobs) do not exceed ``max_iteration_per_job * total_max_jobs``.
+        :param pool_period_min: Time in minutes between two consecutive pools.
+        :param time_limit_per_job: Maximum execution time per single job in minutes.
+            When the time limit is exceeded, the job is aborted.
+        :param compute_time_limit: Maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param local_port: Default port is ``9090`` (tcp). Required for the BOHB workers to communicate,
+            even locally.
+        :param bohb_kwargs: Arguments passed directly to the BOHB object.
         """
         if sys.version_info >= (3, 12):
             logger.warning(
@@ -283,7 +284,7 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
         min_bandwidth: Optional[float] = 1e-3,
     ) -> None:
         """
-        Defaults copied from BOHB constructor, see details in BOHB.__init__
+        The defaults are copied from the BOHB constructor; see ``BOHB.__init__`` for details.
 
         BOHB performs robust and efficient hyperparameter optimization
         at scale by combining the speed of Hyperband searches with the
@@ -302,34 +303,26 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
                  year =         {2018},
             }
 
-        :param eta: float (3)
-            In each iteration, a complete run of sequential halving is executed. In it,
+        :param eta: In each iteration, a complete run of sequential halving is executed. In it,
             after evaluating each configuration on the same subset size, only a fraction of
-            1/eta of them 'advances' to the next round.
-            Must be greater or equal to 2.
-        :param min_budget: float (0.01)
-            The smallest budget to consider. Needs to be positive!
-        :param max_budget: float (1)
-            The largest budget to consider. Needs to be larger than min_budget!
-            The budgets will be geometrically distributed
-            :math:`a^2 + b^2 = c^2 /sim /eta^k` for :math:`k/in [0, 1, ... , num/_subsets - 1]`.
-        :param min_points_in_model: int (None)
-            number of observations to start building a KDE. Default 'None' means
-            dim+1, the bare minimum.
-        :param top_n_percent: int (15)
-            percentage ( between 1 and 99, default 15) of the observations that are considered good.
-        :param num_samples: int (64)
-            number of samples to optimize EI (default 64)
-        :param random_fraction: float (1/3.)
-            fraction of purely random configurations that are sampled from the
-            prior without the model.
-        :param bandwidth_factor: float (3.)
-            to encourage diversity, the points proposed to optimize EI, are sampled
-            from a 'widened' KDE where the bandwidth is multiplied by this factor (default: 3)
-        :param min_bandwidth: float (1e-3)
-            to keep diversity, even when all (good) samples have the same value for one of the parameters,
-            a minimum bandwidth (Default: 1e-3) is used instead of zero.
-
+            ``1/eta`` of them advances to the next round.
+            Must be greater than or equal to ``2``. Default: ``3``.
+        :param min_budget: Smallest budget to consider. Needs to be positive.
+            If not specified, BOHB's own default (``0.01``) is used.
+        :param max_budget: Largest budget to consider. Needs to be larger than ``min_budget``.
+            If not specified, BOHB's own default (``1``) is used.
+            The budgets are geometrically distributed across the brackets, spaced by a factor of ``eta``.
+        :param min_points_in_model: Number of observations needed to start building a KDE.
+            If ``None`` (default), use ``dim + 1``, the bare minimum.
+        :param top_n_percent: Percentage (between ``1`` and ``99``) of the observations that are considered
+            good. Default: ``15``.
+        :param num_samples: Number of samples used to optimize EI. Default: ``64``.
+        :param random_fraction: Fraction of purely random configurations sampled from the prior, without
+            the model. Default: ``1/3``.
+        :param bandwidth_factor: To encourage diversity, the points proposed to optimize EI are sampled from a
+            widened KDE, where the bandwidth is multiplied by this factor. Default: ``3``.
+        :param min_bandwidth: To keep diversity, even when all (good) samples have the same value for one of
+            the parameters, a minimum bandwidth is used instead of zero. Default: ``1e-3``.
         """
         if min_budget:
             self._bohb_kwargs["min_budget"] = min_budget
@@ -346,12 +339,11 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
 
     def start(self) -> None:
         """
-        Start the Optimizer controller function loop()
-        If the calling process is stopped, the controller will stop as well.
+        Start the optimizer controller's function loop. If the calling process is stopped, the controller will
+        stop as well.
 
         .. important::
-            This function returns only after optimization is completed or :meth:`stop` was called.
-
+            This function returns only after the optimization is completed or ```stop``` is called.
         """
         # Step 1: Start a NameServer
         fake_run_id = f"OptimizerBOHB_{time()}"
@@ -401,8 +393,8 @@ class OptimizerBOHB(SearchStrategy, RandomSeed):
 
     def stop(self) -> None:
         """
-        Stop the current running optimization loop,
-        Called from a different thread than the :meth:`start`.
+        Stop the current running optimization loop. Should be called from a different thread than the one
+        running :meth:`start`.
         """
         # After the optimizer run, we must shutdown the master and the nameserver.
         self._bohb.shutdown(shutdown_workers=True)

--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -72,10 +72,10 @@ class _ObjectiveInterface(ABC):
 
 class Objective(_ObjectiveInterface):
     """
-    Optimization ``Objective`` class to maximize / minimize over all experiments. This class will sample a specific
-    scalar from all experiments, and maximize / minimize over single scalar (i.e., title and series combination).
+    An ``Objective`` defines the scalar metric (a title/series combination) that the optimization maximizes or
+    minimizes across all experiments.
 
-    ``SearchStrategy`` and ``HyperParameterOptimizer`` use ``Objective`` in the strategy search algorithm.
+    ``SearchStrategy`` and ``HyperParameterOptimizer`` use ``Objective`` to drive the search algorithm.
     """
 
     def __init__(
@@ -86,24 +86,19 @@ class Objective(_ObjectiveInterface):
         extremum: bool = False,
     ):
         """
-        Construct ``Objective`` object that will return the scalar value for a specific task ID.
+        Construct an ``Objective`` object that will return the scalar value for a specific task ID.
 
-        :param str title: The scalar graph title to sample from.
-        :param str series: The scalar series title to sample from.
-        :param str order: The setting for maximizing or minimizing the objective scalar value.
+        :param title: The scalar graph title to sample from.
+        :param series: The scalar series title to sample from.
+        :param order: The setting for maximizing or minimizing the objective scalar value.
 
             The values are:
 
             - ``max``
             - ``min``
 
-        :param bool extremum: Return the global minimum / maximum reported metric value
-
-            The values are:
-
-            - ``True`` - Return the global minimum / maximum reported metric value.
-            - ``False`` - Return the last value reported for a specific Task. (Default)
-
+        :param extremum: If ``True``, return the global minimum / maximum reported metric value.
+            If ``False`` (default), return the last value reported for a specific Task.
         """
         self.title = title
         self.series = series
@@ -120,7 +115,7 @@ class Objective(_ObjectiveInterface):
         """
         Return a specific task scalar value based on the objective settings (title/series).
 
-        :param str task_id: The Task ID to retrieve scalar from (or ``ClearMLJob`` object).
+        :param task_id: The Task ID to retrieve the scalar from (also accepts a ``Task`` or ``ClearmlJob`` object).
 
         :return: The scalar value.
         """
@@ -160,10 +155,9 @@ class Objective(_ObjectiveInterface):
         """
         Return the current raw value (without sign normalization) of the objective.
 
-        :param str task: The Task or Job to retrieve scalar from (or ``ClearmlJob`` object).
+        :param task: The Task or ``ClearmlJob`` object to retrieve the raw scalar from.
 
-        :return: Tuple(iteration, value) if, and only if, the metric exists. None if the metric does not exist.
-
+        :return: ``Tuple(iteration, value)``  if the metric exists, ``None`` otherwise.
         """
         if isinstance(task, Task):
             task_id = task.id
@@ -205,8 +199,8 @@ class Objective(_ObjectiveInterface):
         """
         Return the sign of the objective.
 
-        - ``+1`` - If maximizing
-        - ``-1`` - If minimizing
+        - ``+1`` - If maximizing.
+        - ``-1`` - If minimizing.
 
         :return: Objective function sign.
         """
@@ -216,16 +210,16 @@ class Objective(_ObjectiveInterface):
         """
         Return the metric title, series pair of the objective.
 
-        :return: (title, series)
+        :return: ``(title, series)`` tuple.
         """
         return self.title, self.series
 
     def get_normalized_objective(self, task_id: Union[str, Task, ClearmlJob]) -> Optional[float]:
         """
         Return a normalized task scalar value based on the objective settings (title/series).
-        I.e. objective is always to maximize the returned value
+        I.e., the returned value should always be maximized.
 
-        :param str task_id: The Task ID to retrieve scalar from.
+        :param task_id: The Task ID to retrieve the scalar from (also accepts a ``Task`` or ``ClearmlJob`` object).
 
         :return: Normalized scalar value.
         """
@@ -244,9 +238,9 @@ class Objective(_ObjectiveInterface):
         """
         Return a list of Tasks of the top performing experiments, based on the title/series objective.
 
-        :param int top_k: The number of Tasks (experiments) to return.
-        :param str optimizer_task_id: Parent optimizer Task ID
-        :param dict task_filter: Optional task_filtering for the query
+        :param top_k: The number of Tasks (experiments) to return.
+        :param optimizer_task_id: Parent optimizer Task ID.
+        :param task_filter: Task filtering for the query.
 
         :return: A list of Task objects, ordered by performance, where index 0 is the best performing Task.
         """
@@ -277,7 +271,7 @@ class Objective(_ObjectiveInterface):
 
     def _get_last_metrics_encode_field(self) -> str:
         """
-        Return encoded representation of the title/series metric.
+        Return an encoded representation of the title/series metric.
 
         :return: The objective title/series.
         """
@@ -377,20 +371,20 @@ class SearchStrategy:
         """
         Initialize a search strategy optimizer.
 
-        :param str base_task_id: The Task ID (str)
-        :param list hyper_parameters: The list of parameter objects to optimize over.
-        :param Objective objective_metric: The Objective metric to maximize / minimize.
-        :param str execution_queue: The execution queue to use for launching Tasks (experiments).
-        :param int num_concurrent_workers: The maximum number of concurrent running machines.
-        :param float pool_period_min: The time between two consecutive pools (minutes).
-        :param float time_limit_per_job: The maximum execution time per single job in minutes. When time limit is
-            exceeded, the job is aborted. (Optional)
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param int min_iteration_per_job: The minimum iterations (of the Objective metric) per single job (Optional)
-        :param int max_iteration_per_job: The maximum iterations (of the Objective metric) per single job.
-            When maximum iterations is exceeded, the job is aborted.  (Optional)
-        :param int total_max_jobs: The total maximum jobs for the optimization process. The default value is ``None``,
+        :param base_task_id: The Task ID to be used as template experiment to optimize.
+        :param hyper_parameters: The list of parameter objects to optimize over.
+        :param objective_metric: The Objective metric to maximize / minimize.
+        :param execution_queue: The execution queue to use for launching Tasks (experiments).
+        :param num_concurrent_workers: The maximum number of concurrent running machines.
+        :param pool_period_min: The time between two consecutive pools (minutes).
+        :param time_limit_per_job: The maximum execution time per single job in minutes.
+            When the time limit is exceeded, the job is aborted.
+        :param compute_time_limit: The maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param min_iteration_per_job: The minimum iterations (of the Objective metric) per single job.
+        :param max_iteration_per_job: The maximum iterations (of the Objective metric) per single job.
+            When this maximum is exceeded, the job is aborted.
+        :param total_max_jobs: The total maximum jobs for the optimization process. The default value is ``None``,
             for unlimited.
         """
         super(SearchStrategy, self).__init__()
@@ -426,12 +420,11 @@ class SearchStrategy:
 
     def start(self) -> None:
         """
-        Start the Optimizer controller function loop(). If the calling process is stopped, the controller will stop
-        as well.
+        Start the optimizer controller's function loop. If the calling process is stopped, the controller will
+        stop as well.
 
         .. important::
-            This function returns only after the optimization is completed or :meth:`stop` was called.
-
+            This function returns only after the optimization is completed or ```stop``` is called.
         """
         counter = 0
         while True:
@@ -444,25 +437,25 @@ class SearchStrategy:
 
     def stop(self) -> None:
         """
-        Stop the current running optimization loop. Called from a different thread than the :meth:`start`.
+        Stop the current running optimization loop. Should be called from a different thread than the one
+        running :meth:`start`.
         """
         self._stop_event.set()
 
     def process_step(self) -> bool:
         """
-        Abstract helper function. Implementation is not required. Default use in start default implementation
-        Main optimization loop, called from the daemon thread created by :meth:`start`.
+        Helper function; implementation is optional. This is the main optimization loop used by the default
+        :meth:`start` implementation, called from the daemon thread that :meth:`start` creates.
 
-        - Call monitor job on every ``ClearmlJob`` in jobs:
+        - Call :meth:`monitor_job` on every ``ClearmlJob`` in jobs:
 
           - Check the performance or elapsed time, and then decide whether to kill the jobs.
 
-        - Call create_job:
+        - Call ``create_job``
 
-          - Check if spare job slots exist, and if they do call create a new job based on previous tested experiments.
+          - Check if spare job slots exist, and if they do, create a new job based on previous tested experiments.
 
-        :return: True, if continue the optimization. False, if immediately stop.
-
+        :return: ``True``, if continuing the optimization. ``False``, if stopping immediately.
         """
         updated_jobs = []
         for job in self._current_jobs:
@@ -502,26 +495,26 @@ class SearchStrategy:
 
     def create_job(self) -> Optional[ClearmlJob]:
         """
-        Abstract helper function. Implementation is not required. Default use in process_step default implementation
-        Create a new job if needed. return the newly created job. If no job needs to be created, return ``None``.
+        Helper function; implementation is optional. Used by the default :meth:`process_step` implementation.
+        Create a new job if needed and return it. Return ``None`` if no job needs to be created.
 
-        :return: A Newly created ClearmlJob object, or None if no ClearmlJob created.
+        :return: A newly created ``ClearmlJob`` object, or ``None`` if no job was created.
         """
         return None
 
     def monitor_job(self, job: ClearmlJob) -> bool:
         """
-        Helper function, Implementation is not required. Default use in process_step default implementation.
-        Check if the job needs to be aborted or already completed.
+        Helper function; implementation is optional. Used by the default :meth:`process_step` implementation.
+        Check if the job needs to be aborted or has already completed.
 
-        If returns ``False``, the job was aborted / completed, and should be taken off the current job list.
+        If this returns ``False``, the job was aborted / completed, and should be taken off the current job list.
 
         If there is a budget limitation, this call should update
-        ``self.budget.compute_time.update`` / ``self.budget.iterations.update``
+        ``self.budget.compute_time.update`` / ``self.budget.iterations.update``.
 
-        :param ClearmlJob job: A ``ClearmlJob`` object to monitor.
+        :param job: A ``ClearmlJob`` object to monitor.
 
-        :return: False, if the job is no longer relevant.
+        :return: ``False``, if the job is no longer relevant.
         """
 
         abort_job = self.update_budget_per_job(job)
@@ -558,27 +551,27 @@ class SearchStrategy:
 
     def get_running_jobs(self) -> Sequence[ClearmlJob]:
         """
-        Return the current running ClearmlJob.
+        Return the current running ``ClearmlJob`` objects.
 
-        :return: List of ClearmlJob objects.
+        :return: List of ``ClearmlJob`` objects.
         """
         return self._current_jobs
 
     def get_created_jobs_ids(self) -> Mapping[str, dict]:
         """
-        Return a Task IDs dict created by this optimizer until now, including completed and running jobs.
-        The values of the returned dict are the parameters used in the specific job
+        Return a dict of Task IDs created by this optimizer so far, including completed and running jobs.
+        The values of the returned dict are the parameters used in the specific job.
 
-        :return: dict of task IDs (str) as keys, and their parameters dict as values.
+        :return: A dict of Task IDs as keys, and their parameters dict as values.
         """
         return {job_id: job_val[1] for job_id, job_val in self._created_jobs_ids.items()}
 
     def get_created_jobs_tasks(self) -> Mapping[str, dict]:
         """
-        Return a Task IDs dict created by this optimizer until now.
-        The values of the returned dict are the ClearmlJob.
+        Return a dict of Task IDs created by this optimizer so far.
+        The values of the returned dict are the ``ClearmlJob`` objects.
 
-        :return: dict of task IDs (str) as keys, and their ClearmlJob as values.
+        :return: A dict of Task IDs as keys, and their ``ClearmlJob`` objects as values.
         """
         return {job_id: job_val[0] for job_id, job_val in self._created_jobs_ids.items()}
 
@@ -586,7 +579,7 @@ class SearchStrategy:
         """
         Return a list of Tasks of the top performing experiments, based on the controller ``Objective`` object.
 
-        :param int top_k: The number of Tasks (experiments) to return.
+        :param top_k: The number of Tasks (experiments) to return.
 
         :return: A list of Task objects, ordered by performance, where index 0 is the best performing Task.
         """
@@ -604,55 +597,55 @@ class SearchStrategy:
         Return a list of pairs (Task ID, scalar metric dict) of the top performing experiments.
         Order is based on the controller ``Objective`` object.
 
-        :param int top_k: The number of Tasks (experiments) to return.
-        :param all_metrics: Default False, only return the objective metric on the metrics dictionary.
-            If True, return all scalar metrics of the experiment
-        :param only_completed: return only completed Tasks. Default False.
+        :param top_k: The number of Tasks (experiments) to return.
+        :param all_metrics: If ``False`` (default), only the objective metric is included in the metrics
+            dictionary. If ``True``, all scalar metrics of the experiment are included.
+        :param only_completed: If ``True``, return only completed Tasks. Default: ``False``.
 
         :return: A list of pairs (Task ID, metric values dict), ordered by performance,
-        where index 0 is the best performing Task.
-        Example w/ all_metrics=False:
+            where index 0 is the best performing Task.
+            Example with ``all_metrics=False``:
 
-        .. code-block:: py
+            .. code-block:: py
 
-            [
-                ('0593b76dc7234c65a13a301f731958fa',
-                    {
-                        'accuracy per class/cat': {
-                            'metric': 'accuracy per class',
-                            'variant': 'cat',
-                            'value': 0.119,
-                            'min_value': 0.119,
-                            'max_value': 0.782
-                        },
-                    }
-                ),
-            ]
+                [
+                    ('0593b76dc7234c65a13a301f731958fa',
+                        {
+                            'accuracy per class/cat': {
+                                'metric': 'accuracy per class',
+                                'variant': 'cat',
+                                'value': 0.119,
+                                'min_value': 0.119,
+                                'max_value': 0.782
+                            },
+                        }
+                    ),
+                ]
 
-        Example w/ all_metrics=True:
+            Example with ``all_metrics=True``:
 
-        .. code-block:: py
+            .. code-block:: py
 
-            [
-                ('0593b76dc7234c65a13a301f731958fa',
-                    {
-                        'accuracy per class/cat': {
-                            'metric': 'accuracy per class',
-                            'variant': 'cat',
-                            'value': 0.119,
-                            'min_value': 0.119,
-                            'max_value': 0.782
-                        },
-                        'accuracy per class/deer': {
-                            'metric': 'accuracy per class',
-                            'variant': 'deer',
-                            'value': 0.219,
-                            'min_value': 0.219,
-                            'max_value': 0.282
-                        },
-                    }
-                ),
-            ]
+                [
+                    ('0593b76dc7234c65a13a301f731958fa',
+                        {
+                            'accuracy per class/cat': {
+                                'metric': 'accuracy per class',
+                                'variant': 'cat',
+                                'value': 0.119,
+                                'min_value': 0.119,
+                                'max_value': 0.782
+                            },
+                            'accuracy per class/deer': {
+                                'metric': 'accuracy per class',
+                                'variant': 'deer',
+                                'value': 0.219,
+                                'min_value': 0.219,
+                                'max_value': 0.282
+                            },
+                        }
+                    ),
+                ]
         """
         additional_filters = dict(page_size=int(top_k), page=0)
         if only_completed:
@@ -697,19 +690,20 @@ class SearchStrategy:
     ) -> Sequence[Union[str, dict]]:
         """
         Return a list of dictionaries of the top performing experiments.
-        Example: ``[{'task_id': Task-ID, 'metrics': scalar-metric-dict, 'hyper_parameters': Hyper-Parameters},]``
+        Example: ``[{'task_id': TASK_ID, 'metrics': SCALAR_METRIC_DICT, 'hyper_parameters': HYPER_PARAMETERS},]``
 
         Order is based on the controller ``Objective`` object.
 
-        :param int top_k: The number of Tasks (experiments) to return.
-        :param all_metrics: Default False, only return the objective metric on the metrics dictionary.
-            If True, return all scalar metrics of the experiment
-        :param all_hyper_parameters: Default False. If True, return all the hyperparameters from all the sections.
-        :param only_completed: return only completed Tasks. Default False.
+        :param top_k: The number of Tasks (experiments) to return.
+        :param all_metrics: If ``False`` (default), only the objective metric is included in the metrics
+            dictionary. If ``True``, all scalar metrics of the experiment are included.
+        :param all_hyper_parameters: If ``True``, return all the hyperparameters from all the sections.
+            If ``False`` (default), return only the hyperparameters that are part of the optimization search space.
+        :param only_completed: If ``True``, return only completed Tasks. Default: ``False``.
 
         :return: A list of dictionaries ``({task_id: '', hyper_parameters: {}, metrics: {}})``, ordered by performance,
             where index 0 is the best performing Task.
-            Example w/ all_metrics=False:
+            Example with ``all_metrics=False``:
 
             .. code-block:: py
 
@@ -729,7 +723,7 @@ class SearchStrategy:
                     },
                 ]
 
-            Example w/ all_metrics=True:
+            Example with ``all_metrics=True``:
 
             .. code-block:: py
 
@@ -850,9 +844,10 @@ class SearchStrategy:
         self,
     ) -> Union[Tuple[str, str], List[Tuple[str, str]]]:
         """
-        Return the metric title, series pair of the objective.
+        Return the metric title/series pair(s) of the objective.
 
-        :return: (title, series)
+        :return: A single ``(title, series)`` tuple for a single-objective optimization, or a list of
+            ``(title, series)`` tuples for a multi-objective optimization.
         """
         objective = self._objective_metric.get_objective_metric()
         return objective[0] if self._objective_metric.len == 1 else objective
@@ -867,7 +862,17 @@ class SearchStrategy:
         **kwargs: Any,
     ) -> ClearmlJob:
         """
-        Create a Job using the specified arguments, ``ClearmlJob`` for details.
+        Create a job using the specified arguments. See ``ClearmlJob`` for details.
+
+        :param base_task_id: Task ID to clone from.
+        :param parameter_override: Dictionary of parameter names and values to override on the cloned Task.
+        :param task_overrides: Task-object-specific overrides.
+            For example: ``{'script.version_num': None, 'script.branch': 'main'}``.
+        :param tags: Additional tags to add to the newly created Task.
+        :param parent: Parent Task ID for the newly created Task.
+            If not specified, defaults to the optimizer's default parent Task (see :meth:`set_job_default_parent`).
+        :param kwargs: Additional arguments passed directly to the Job class constructor
+            (``ClearmlJob`` by default; see :meth:`set_job_class`).
 
         :return: A newly created Job instance.
         """
@@ -915,7 +920,7 @@ class SearchStrategy:
         """
         Set the class to use for the :meth:`helper_create_job` function.
 
-        :param ClearmlJob job_class: The Job Class type.
+        :param job_class: The Job class to use.
         """
         self._job_class = job_class
 
@@ -927,8 +932,8 @@ class SearchStrategy:
         """
         Set the default parent for all Jobs created by the :meth:`helper_create_job` method.
 
-        :param str job_parent_task_id: The parent Task ID.
-        :param str project_name: If specified, create the jobs in the specified project
+        :param job_parent_task_id: The parent Task ID.
+        :param project_name: If specified, create the jobs in the specified project.
         """
         self._job_parent_id = job_parent_task_id
         # noinspection PyProtectedMember
@@ -946,13 +951,12 @@ class SearchStrategy:
         """
         Set the function used to name a newly created job.
 
-        :param callable naming_function: Callable function for naming a newly created job.
+        :param naming_function: Callable function for naming a newly created job.
             Use the following format:
 
             .. code-block:: py
 
-                naming_functor(base_task_name, argument_dict) -> str
-
+                naming_function(base_task_name, argument_dict) -> str
         """
         self._naming_function = naming_function
 
@@ -961,7 +965,7 @@ class SearchStrategy:
         Set the optimizer task object to be used to store/generate reports on the optimization process.
         Usually this is the current task of this process.
 
-        :param Task task: The optimizer`s current Task.
+        :param task: The optimizer's current Task.
         """
         self._optimizer_task = task
 
@@ -1013,11 +1017,11 @@ class SearchStrategy:
         additional_filters: Optional[dict] = None,
     ) -> Union[Sequence[str], Sequence[List]]:
         """
-        Helper function. Return a list of tasks is tagged automl, with specific ``status``, ordered by ``sort_field``.
+        Helper function. Return a list of tasks tagged automl, with specific ``status``, ordered by ``order_by``.
 
-        :param str parent_task_id: The base Task ID (parent).
+        :param parent_task_id: The base Task ID (parent).
         :param status: The current status of requested tasks (for example, ``in_progress`` and ``completed``).
-        :param str order_by: The field name to sort results.
+        :param order_by: The field name to sort results.
 
             Examples:
 
@@ -1029,10 +1033,12 @@ class SearchStrategy:
                 "execution.parameters.name"
                 "updated"
 
-        :param additional_fields: Optional, list of fields (str) to return next to the Task ID,
-            this implies return value is a list of pairs
-        :param dict additional_filters: The additional task filters.
-        :return: A list of Task IDs (str)
+        :param additional_fields: List of fields to return next to the Task ID. If provided, the return value
+            becomes a list of ``[task_id, field_value, ...]`` lists.
+        :param additional_filters: The additional task filters.
+
+        :return: A list of Task IDs, or if ``additional_fields`` is provided, a list of ``[task_id, field_value, ...]``
+            lists.
         """
         task_filter = {
             "parent": parent_task_id,
@@ -1081,11 +1087,11 @@ class SearchStrategy:
         additional_filters: Optional[dict] = None,
     ) -> Sequence[Task]:
         """
-        Helper function. Return a list of tasks tagged automl, with specific ``status``, ordered by ``sort_field``.
+        Helper function. Return a list of tasks tagged automl, with specific ``status``, ordered by ``order_by``.
 
-        :param str parent_task_id: The base Task ID (parent).
+        :param parent_task_id: The base Task ID (parent).
         :param status: The current status of requested tasks (for example, ``in_progress`` and ``completed``).
-        :param str order_by: The field name to sort results.
+        :param order_by: The field name to sort results.
 
             Examples:
 
@@ -1097,8 +1103,9 @@ class SearchStrategy:
                 "execution.parameters.name"
                 "updated"
 
-        :param dict additional_filters: The additional task filters.
-        :return: A list of Task objects
+        :param additional_filters: The additional task filters.
+
+        :return: A list of Task objects.
         """
         return [
             Task.get_task(task_id=t_id)
@@ -1130,9 +1137,9 @@ class MultiObjective(_ObjectiveInterface):
 
     def get_objective(self, task_id: Union[str, Task, ClearmlJob]) -> Optional[List[float]]:
         """
-        Return a specific task scalar values based on the objective settings (title/series).
+        Return a task's scalar values based on the objective settings (title/series).
 
-        :param str task_id: The Task ID to retrieve scalar from (or ``ClearMLJob`` object).
+        :param task_id: The Task ID to retrieve the scalars from (also accepts a ``Task`` or ``ClearmlJob`` object).
 
         :return: The scalar values.
         """
@@ -1145,8 +1152,10 @@ class MultiObjective(_ObjectiveInterface):
         """
         Return the current raw value (without sign normalization) of each objective.
 
-        :param str task: The Task or Job to retrieve scalar from (or ``ClearmlJob`` object).
-        :return: List[Optional[Tuple(iteration, value)]]. None if the metric does not exist.
+        :param task: The Task or ``ClearmlJob`` object to retrieve the raw scalars from.
+
+        :return: A list of ``(iteration, value)`` tuples, one per objective, or ``None`` if any objective's
+            metric does not exist.
         """
         objective = [o.get_current_raw_objective(task) for o in self.objectives]
         if any(o is None for o in objective):
@@ -1157,8 +1166,8 @@ class MultiObjective(_ObjectiveInterface):
         """
         Return the sign of the objectives.
 
-        - ``+1`` - If maximizing
-        - ``-1`` - If minimizing
+        - ``+1`` - If maximizing.
+        - ``-1`` - If minimizing.
 
         :return: Objective function signs.
         """
@@ -1166,10 +1175,10 @@ class MultiObjective(_ObjectiveInterface):
 
     def get_normalized_objective(self, task_id: Union[str, Task, ClearmlJob]) -> Optional[List[float]]:
         """
-        Return a normalized task scalar values based on the objective settings (title/series).
-        I.e. objective is always to maximize the returned value
+        Return normalized task scalar values based on the objective settings (title/series).
+        I.e., the returned values should always be maximized.
 
-        :param str task_id: The Task ID to retrieve scalars from.
+        :param task_id: The Task ID to retrieve the scalars from (also accepts a ``Task`` or ``ClearmlJob`` object).
 
         :return: Normalized scalar values.
         """
@@ -1182,7 +1191,7 @@ class MultiObjective(_ObjectiveInterface):
         """
         Return the metric title, series pairs of the objectives.
 
-        :return: List[(title, series)]
+        :return: A list of ``(title, series)`` tuples, one per objective.
         """
         return [o.get_objective_metric() for o in self.objectives]
 
@@ -1200,9 +1209,9 @@ class MultiObjective(_ObjectiveInterface):
         A trial dominates another trial if all its objective metrics are greater or equal than the other
         trial's and there is at least one objective metric that is strictly greater than the other.
 
-        :param int top_k: The number of Tasks (experiments) to return.
-        :param str optimizer_task_id: Parent optimizer Task ID
-        :param dict task_filter: Optional task_filtering for the query
+        :param top_k: The number of Tasks (experiments) to return.
+        :param optimizer_task_id: Parent optimizer Task ID.
+        :param task_filter: Task filtering for the query.
 
         :return: A list of Task objects, ordered by performance, where index 0 is the best performing Task.
         """
@@ -1279,21 +1288,21 @@ class GridSearch(SearchStrategy):
         **_: Any,
     ):
         """
-        Initialize a grid search optimizer
+        Initialize a grid search optimizer.
 
-        :param str base_task_id: The Task ID.
-        :param list hyper_parameters: The list of parameter objects to optimize over.
-        :param Objective objective_metric: The Objective metric to maximize / minimize.
-        :param str execution_queue: The execution queue to use for launching Tasks (experiments).
-        :param int num_concurrent_workers: The maximum number of concurrent running machines.
-        :param float pool_period_min: The time between two consecutive pools (minutes).
-        :param float time_limit_per_job: The maximum execution time per single job in minutes. When the time limit is
-            exceeded job is aborted. (Optional)
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param int max_iteration_per_job: The maximum iterations (of the Objective metric)
-            per single job, When exceeded, the job is aborted.
-        :param int total_max_jobs: The total maximum jobs for the optimization process. The default is ``None``, for
+        :param base_task_id: The Task ID to be used as template experiment to optimize.
+        :param hyper_parameters: The list of parameter objects to optimize over.
+        :param objective_metric: The Objective metric to maximize / minimize.
+        :param execution_queue: The execution queue to use for launching Tasks (experiments).
+        :param num_concurrent_workers: The maximum number of concurrent running machines.
+        :param pool_period_min: The time between two consecutive pools (minutes).
+        :param time_limit_per_job: The maximum execution time per single job in minutes.
+            When the time limit is exceeded, the job is aborted.
+        :param compute_time_limit: The maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param max_iteration_per_job: The maximum iterations (of the Objective metric) per single job.
+            When this maximum is exceeded, the job is aborted.
+        :param total_max_jobs: The total maximum jobs for the optimization process. The default is ``None``, for
             unlimited.
         """
         super(GridSearch, self).__init__(
@@ -1315,7 +1324,7 @@ class GridSearch(SearchStrategy):
         """
         Create a new job if needed. Return the newly created job. If no job needs to be created, return ``None``.
 
-        :return: A newly created ClearmlJob object, or None if no ClearmlJob is created.
+        :return: A newly created ``ClearmlJob`` object, or ``None`` if no job is created.
         """
         try:
             parameters = self._next_configuration()
@@ -1360,19 +1369,19 @@ class RandomSearch(SearchStrategy):
         """
         Initialize a random search optimizer.
 
-        :param str base_task_id: The Task ID.
-        :param list hyper_parameters: The list of Parameter objects to optimize over.
-        :param Objective objective_metric: The Objective metric to maximize / minimize.
-        :param str execution_queue: The execution queue to use for launching Tasks (experiments).
-        :param int num_concurrent_workers: The maximum umber of concurrent running machines.
-        :param float pool_period_min: The time between two consecutive pools (minutes).
-        :param float time_limit_per_job: The maximum execution time per single job in minutes,
-            when time limit is exceeded job is aborted. (Optional)
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param int max_iteration_per_job: The maximum iterations (of the Objective metric)
-            per single job. When exceeded, the job is aborted.
-        :param int total_max_jobs: The total maximum jobs for the optimization process. The default is ``None``, for
+        :param base_task_id: The Task ID to be used as template experiment to optimize.
+        :param hyper_parameters: The list of parameter objects to optimize over.
+        :param objective_metric: The Objective metric to maximize / minimize.
+        :param execution_queue: The execution queue to use for launching Tasks (experiments).
+        :param num_concurrent_workers: The maximum number of concurrent running machines.
+        :param pool_period_min: The time between two consecutive pools (minutes).
+        :param time_limit_per_job: The maximum execution time per single job in minutes.
+            When the time limit is exceeded, the job is aborted.
+        :param compute_time_limit: The maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param max_iteration_per_job: The maximum iterations (of the Objective metric) per single job.
+            When this maximum is exceeded, the job is aborted.
+        :param total_max_jobs: The total maximum jobs for the optimization process. The default is ``None``, for
             unlimited.
         """
         super(RandomSearch, self).__init__(
@@ -1394,7 +1403,7 @@ class RandomSearch(SearchStrategy):
         """
         Create a new job if needed. Return the newly created job. If no job needs to be created, return ``None``.
 
-        :return: A newly created ClearmlJob object, or None if no ClearmlJob created
+        :return: A newly created ``ClearmlJob`` object, or ``None`` if no job is created.
         """
         parameters = None
 
@@ -1421,8 +1430,8 @@ class RandomSearch(SearchStrategy):
 
 class HyperParameterOptimizer:
     """
-    Hyperparameter search controller. Clones the base experiment, changes arguments and tries to maximize/minimize
-    the defined objective.
+    Hyperparameter search controller. Clones the base experiment, changes its arguments, and tries to maximize /
+    minimize the defined objective.
     """
 
     _tag = "optimization"
@@ -1448,16 +1457,16 @@ class HyperParameterOptimizer:
         """
         Create a new hyperparameter controller. The newly created object will launch and monitor the new experiments.
 
-        :param str base_task_id: The Task ID to be used as template experiment to optimize.
-        :param list hyper_parameters: The list of Parameter objects to optimize over.
+        :param base_task_id: The Task ID to be used as template experiment to optimize.
+        :param hyper_parameters: The list of parameter objects to optimize over.
         :param objective_metric_title: The Objective metric title(s) to maximize / minimize
             (for example, ``validation``, ``["validation", "loss"]``). If ``objective_metric_title`` is a sequence
             (used to optimize multiple objectives at the same time), then ``objective_metric_series`` and
-             ``objective_metric_sign`` have to be sequences of the same length. Each title will be matched
-             with the respective series and sign
-        :param Union[str, Sequence[str]] objective_metric_series: The Objective metric series to maximize / minimize
+            ``objective_metric_sign`` have to be sequences of the same length. Each title will be matched
+            with the respective series and sign.
+        :param objective_metric_series: The Objective metric series to maximize / minimize
             (for example, ``loss_series``, ``["validation_series", "loss_series"]``).
-        :param Union[str, Sequence[str]] objective_metric_sign: The objectives to maximize / minimize.
+        :param objective_metric_sign: The objectives to maximize / minimize.
             The values are:
 
           - ``min`` - Minimize the last reported value for the specified title/series scalar.
@@ -1465,37 +1474,39 @@ class HyperParameterOptimizer:
           - ``min_global`` - Minimize the min value of *all* reported values for the specific title/series scalar.
           - ``max_global`` - Maximize the max value of *all* reported values for the specific title/series scalar.
 
-        :param class.SearchStrategy optimizer_class: The SearchStrategy optimizer to use for the hyperparameter search
-        :param int max_number_of_concurrent_tasks: The maximum number of concurrent Tasks (experiments) running at the
+        :param optimizer_class: The ``SearchStrategy`` optimizer class (or instance) to use for the hyperparameter
+            search.
+        :param max_number_of_concurrent_tasks: The maximum number of concurrent Tasks (experiments) running at the
             same time.
-        :param str execution_queue: The execution queue to use for launching Tasks (experiments).
-        :param float optimization_time_limit: The maximum time (minutes) for the entire optimization process. The
+        :param execution_queue: The execution queue to use for launching Tasks (experiments).
+        :param optimization_time_limit: The maximum time (minutes) for the entire optimization process. The
             default is ``None``, indicating no time limit.
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param bool auto_connect_task: Store optimization arguments and configuration in the Task.
+        :param compute_time_limit: The maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param auto_connect_task: Store optimization arguments and configuration in the Task.
             The values are:
 
           - ``True`` - The optimization argument and configuration will be stored in the Task. All arguments will
-              be under the hyperparameter section ``opt``, and the optimization hyper_parameters space will be
-              stored in the Task configuration object section.
+            be under the hyperparameter section ``opt``, and the optimization hyper_parameters space will be
+            stored in the Task configuration object section.
           - ``False`` - Do not store with Task.
           - ``Task`` - A specific Task object to connect the optimization process with.
 
-        :param bool always_create_task: Always create a new Task.
+        :param always_create_task: Always create a new Task.
             The values are:
 
           - ``True`` - No current Task initialized. Create a new task named ``optimization`` in the ``base_task_id``
-              project.
-          - ``False`` - Use the :py:meth:`task.Task.current_task` (if exists) to report statistics.
+            project.
+          - ``False`` - Use the :meth:`Task.current_task` (if exists) to report statistics.
 
-        :param str spawn_project: If project name is specified, create all optimization Jobs (Tasks) in the
-            specified project instead of the original base_task_id project.
+        :param spawn_project: If project name is specified, create all optimization Jobs (Tasks) in the
+            specified project instead of the original ``base_task_id`` project.
 
-        :param int save_top_k_tasks_only: If specified and above 0, keep only the top_k performing Tasks,
-            and archive the rest of the created Tasks. Default: -1 keep everything, nothing will be archived.
+        :param save_top_k_tasks_only: If specified and greater than ``0``, keep only that many top-performing
+            Tasks, and archive the rest of the created Tasks. If not specified (default), keep everything;
+            nothing will be archived.
 
-        :param ** optimizer_kwargs: Arguments passed directly to the optimizer constructor.
+        :param optimizer_kwargs: Arguments passed directly to the optimizer constructor.
 
             Example:
 
@@ -1660,10 +1671,10 @@ class HyperParameterOptimizer:
     ) -> bool:
         """
         Start the HyperParameterOptimizer controller completely locally. Both the optimizer task
-        and all spawned substasks are run on the local machine using the current environment.
+        and all spawned subtasks are run on the local machine using the current environment.
         If the calling process is stopped, then the controller stops as well.
 
-        :param Callable job_complete_callback: Callback function, called when a job is completed.
+        :param job_complete_callback: Callback function, called when a job is completed.
 
             .. code-block:: py
 
@@ -1676,8 +1687,7 @@ class HyperParameterOptimizer:
                 ):
                     pass
 
-        :return: True, if the controller started. False, if the controller did not start.
-
+        :return: ``True``, if the controller started. ``False``, if the controller did not start.
         """
         self.optimizer.set_job_class(LocalClearmlJob)
         return self.start(job_complete_callback=job_complete_callback)
@@ -1690,7 +1700,7 @@ class HyperParameterOptimizer:
         Start the HyperParameterOptimizer controller. If the calling process is stopped, then the controller stops
         as well.
 
-        :param Callable job_complete_callback: Callback function, called when a job is completed.
+        :param job_complete_callback: Callback function, called when a job is completed.
 
             .. code-block:: py
 
@@ -1703,8 +1713,7 @@ class HyperParameterOptimizer:
                 ):
                     pass
 
-        :return: True, if the controller started. False, if the controller did not start.
-
+        :return: ``True``, if the controller started. ``False``, if the controller did not start.
         """
         if not self.optimizer:
             return False
@@ -1731,9 +1740,10 @@ class HyperParameterOptimizer:
         """
         Stop the HyperParameterOptimizer controller and the optimization thread.
 
-        :param float timeout: Wait timeout for the optimization thread to exit (minutes).
+        :param timeout: Wait timeout for the optimization thread to exit (minutes).
             The default is ``None``, indicating do not wait to terminate immediately.
-        :param wait_for_reporter: Wait for reporter to flush data.
+        :param wait_for_reporter: If ``True`` (default), wait for the reporter thread to flush its data before
+            returning.
         """
         if not self._thread or not self._stop_event or not self.optimizer:
             if self._thread_reporter and wait_for_reporter:
@@ -1760,7 +1770,7 @@ class HyperParameterOptimizer:
 
     def is_active(self) -> bool:
         """
-        Is the optimization procedure active (still running)
+        Return whether the optimization procedure is active (still running).
 
         The values are:
 
@@ -1768,7 +1778,7 @@ class HyperParameterOptimizer:
         - ``False`` - The optimization procedure is not active (not still running).
 
         .. note::
-            If the daemon thread has not yet started, ``is_active`` returns ``True``.
+            If the daemon thread has not yet started, ```is_active``` returns ```True```.
 
         :return: A boolean indicating whether the optimization procedure is active (still running) or stopped.
         """
@@ -1776,12 +1786,12 @@ class HyperParameterOptimizer:
 
     def is_running(self) -> bool:
         """
-        Is the optimization controller is running
+        Return whether the optimization controller is running.
 
         The values are:
 
         - ``True`` - The optimization procedure is running.
-        - ``False`` - The optimization procedure is running.
+        - ``False`` - The optimization procedure is not running.
 
         :return: A boolean indicating whether the optimization procedure is active (still running) or stopped.
         """
@@ -1792,13 +1802,12 @@ class HyperParameterOptimizer:
         Wait for the optimizer to finish.
 
         .. note::
-            This method does not stop the optimizer. Call :meth:`stop` to terminate the optimizer.
+            This method does not stop the optimizer. Call ```stop``` to terminate the optimizer.
 
-        :param float timeout: The timeout to wait for the optimization to complete (minutes).
-            If ``None``, then wait until we reached the timeout, or optimization completed.
+        :param timeout: The timeout to wait for the optimization to complete (minutes).
+            If ``None``, wait indefinitely until the optimization completes.
 
-        :return: True, if the optimization finished. False, if the optimization timed out.
-
+        :return: ``True``, if the optimization finished. ``False``, if the optimization timed out.
         """
         if not self.is_running():
             return True
@@ -1824,11 +1833,11 @@ class HyperParameterOptimizer:
         specific_time: Optional[datetime] = None,
     ) -> None:
         """
-        Set a time limit for the HyperParameterOptimizer controller. If we reached the time limit, stop the optimization
-        process. If ``specific_time`` is provided, use it; otherwise, use the ``in_minutes``.
+        Set a time limit for the HyperParameterOptimizer controller. Once the time limit is reached, stop the
+        optimization process. If ``specific_time`` is provided, use it; otherwise, use the ``in_minutes``.
 
-        :param float in_minutes: The maximum processing time from current time (minutes).
-        :param datetime specific_time: The specific date/time limit.
+        :param in_minutes: The maximum processing time from current time (minutes).
+        :param specific_time: The specific date/time limit.
         """
         if specific_time:
             self.optimization_timeout = specific_time.timestamp()
@@ -1845,7 +1854,7 @@ class HyperParameterOptimizer:
 
     def elapsed(self) -> float:
         """
-        Return minutes elapsed from controller stating time stamp.
+        Return minutes elapsed from controller starting time stamp.
 
         :return: The minutes from controller start time. A negative value means the process has not started yet.
         """
@@ -1855,7 +1864,7 @@ class HyperParameterOptimizer:
 
     def reached_time_limit(self) -> bool:
         """
-        Did the optimizer reach the time limit
+        Return whether the optimizer has reached the time limit.
 
         The values are:
 
@@ -1864,7 +1873,7 @@ class HyperParameterOptimizer:
 
         This method returns immediately, it does not wait for the optimizer.
 
-        :return: True, if optimizer is running and we passed the time limit, otherwise returns False.
+        :return: ``True``, if the optimizer is running and the time limit has passed. ``False``, otherwise.
         """
         if self.optimization_start_time is None:
             return False
@@ -1877,7 +1886,7 @@ class HyperParameterOptimizer:
         """
         Return a list of Tasks of the top performing experiments, based on the controller ``Objective`` object.
 
-        :param int top_k: The number of Tasks (experiments) to return.
+        :param top_k: The number of Tasks (experiments) to return.
 
         :return: A list of Task objects, ordered by performance, where index 0 is the best performing Task.
         """
@@ -1894,19 +1903,20 @@ class HyperParameterOptimizer:
     ) -> Sequence[Union[str, dict]]:
         """
         Return a list of dictionaries of the top performing experiments.
-        Example: ``[{'task_id': Task-ID, 'metrics': scalar-metric-dict, 'hyper_parameters': Hyper-Parameters},]``
+        Example: ``[{'task_id': TASK_ID, 'metrics': SCALAR_METRIC_DICT, 'hyper_parameters': HYPER_PARAMETERS},]``
 
         Order is based on the controller ``Objective`` object.
 
-        :param int top_k: The number of Tasks (experiments) to return.
-        :param all_metrics: Default False, only return the objective metric on the metrics dictionary.
-            If True, return all scalar metrics of the experiment
-        :param all_hyper_parameters: Default False. If True, return all the hyperparameters from all the sections.
-        :param only_completed: return only completed Tasks. Default False.
+        :param top_k: The number of Tasks (experiments) to return.
+        :param all_metrics: If ``False`` (default), only the objective metric is included in the metrics
+            dictionary. If ``True``, all scalar metrics of the experiment are included.
+        :param all_hyper_parameters: If ``True``, return all the hyperparameters from all the sections.
+            If ``False`` (default), return only the hyperparameters that are part of the optimization search space.
+        :param only_completed: If ``True``, return only completed Tasks. Default: ``False``.
 
         :return: A list of dictionaries ``({task_id: '', hyper_parameters: {}, metrics: {}})``, ordered by performance,
             where index 0 is the best performing Task.
-            Example w/ all_metrics=False:
+            Example with ``all_metrics=False``:
 
             .. code-block:: py
 
@@ -1926,7 +1936,7 @@ class HyperParameterOptimizer:
                     },
                 ]
 
-            Example w/ all_metrics=True:
+            Example with ``all_metrics=True``:
 
             .. code-block:: py
 
@@ -1974,7 +1984,7 @@ class HyperParameterOptimizer:
         """
         Set the Job class to use when the optimizer spawns new Jobs.
 
-        :param ClearmlJob job_class: The Job Class type.
+        :param job_class: The Job class to use.
         """
         self.optimizer.set_job_class(job_class)
 
@@ -1983,7 +1993,7 @@ class HyperParameterOptimizer:
         Set reporting period for the accumulated objective report (minutes). This report is sent on the Optimizer Task,
         and collects the Objective metric from all running jobs.
 
-        :param float report_period_minutes: The reporting period (minutes). The default is once every 10 minutes.
+        :param report_period_minutes: The reporting period (minutes). The default is once every 10 minutes.
         """
         self._report_period_min = float(report_period_minutes)
 
@@ -2000,18 +2010,20 @@ class HyperParameterOptimizer:
         Return a list of Tasks of the top performing experiments
         for a specific HyperParameter Optimization session (i.e. Task ID), based on the title/series objective.
 
-        :param str objective_metric_title: The Objective metric title to maximize / minimize (for example,
+        :param objective_metric_title: The Objective metric title to maximize / minimize (for example,
             ``validation``).
-        :param str objective_metric_series: The Objective metric series to maximize / minimize (for example, ``loss``).
-        :param str objective_metric_sign: The objective to maximize / minimize.
+        :param objective_metric_series: The Objective metric series to maximize / minimize (for example, ``loss``).
+        :param objective_metric_sign: The objective to maximize / minimize.
             The values are:
 
           - ``min`` - Minimize the last reported value for the specified title/series scalar.
           - ``max`` - Maximize the last reported value for the specified title/series scalar.
           - ``min_global`` - Minimize the min value of *all* reported values for the specific title/series scalar.
           - ``max_global`` - Maximize the max value of *all* reported values for the specific title/series scalar.
-        :param str optimizer_task_id: Parent optimizer Task ID
+
+        :param optimizer_task_id: Parent optimizer Task ID.
         :param top_k: The number of Tasks (experiments) to return.
+
         :return: A list of Task objects, ordered by performance, where index 0 is the best performing Task.
         """
         objective = Objective(
@@ -2432,8 +2444,7 @@ class HyperParameterOptimizer:
 
                 def trim_value(value: str) -> str:
                     """
-                    Keep the first 6 characters of a string value and replace the remaining parts by "...".
-                    Applies as well if the string is longer than 6 characters.
+                    Truncate a string value to its first 6 characters, followed by ``"..."``.
                     """
                     return f"{value[:6]}..."
 

--- a/clearml/automation/optuna/optuna.py
+++ b/clearml/automation/optuna/optuna.py
@@ -145,32 +145,39 @@ class OptimizerOptuna(SearchStrategy):
         **optuna_kwargs: Any
     ) -> None:
         """
-        Initialize an Optuna search strategy optimizer
-        Optuna performs robust and efficient hyperparameter optimization at scale by combining.
-        Specific hyperparameter pruning strategy can be selected via `sampler` and `pruner` arguments
+        Initialize an Optuna search strategy optimizer.
+        Optuna performs robust and efficient hyperparameter optimization at scale.
+        A specific hyperparameter pruning strategy can be selected via the ``optuna_sampler`` and
+        ``optuna_pruner`` arguments.
 
-        :param str base_task_id: Task ID (str)
-        :param list hyper_parameters: list of Parameter objects to optimize over
-        :param Objective objective_metric: Objective metric to maximize / minimize
-        :param str execution_queue: execution queue to use for launching Tasks (experiments).
-        :param int num_concurrent_workers: Limit number of concurrent running Tasks (machines)
-        :param int max_iteration_per_job: number of iteration per job
-            'iterations' are the reported iterations for the specified objective,
+        :param base_task_id: Task ID to be used as template experiment to optimize.
+        :param hyper_parameters: List of parameter objects to optimize over.
+        :param objective_metric: Objective metric to maximize / minimize.
+        :param execution_queue: Execution queue to use for launching Tasks (experiments).
+        :param num_concurrent_workers: Maximum number of concurrent running Tasks (machines).
+        :param max_iteration_per_job: Number of iterations per job.
+            ``iterations`` are the reported iterations for the specified objective,
             not the maximum reported iteration of the Task.
-        :param int total_max_jobs: total maximum job for the optimization process.
+        :param total_max_jobs: Total maximum jobs for the optimization process.
             Must be provided in order to calculate the total budget for the optimization process.
-            The total budget is measured by "iterations" (see above)
-            and will be set to `max_iteration_per_job * total_max_jobs`
-            This means more than total_max_jobs could be created, as long as the cumulative iterations
-            (summed over all created jobs) will not exceed `max_iteration_per_job * total_max_jobs`
-        :param float pool_period_min: time in minutes between two consecutive pools
-        :param int min_iteration_per_job: The minimum number of iterations (of the Objective metric) per single job,
-            before early stopping the Job. (Optional)
-        :param float time_limit_per_job: Optional, maximum execution time per single job in minutes,
-            when time limit is exceeded job is aborted
-        :param float compute_time_limit: The maximum compute time in minutes. When time limit is exceeded,
-            all jobs aborted. (Optional)
-        :param optuna_kwargs: arguments passed directly to the Optuna object
+            The total budget is measured in ``iterations`` (see above)
+            and will be set to ``max_iteration_per_job * total_max_jobs``.
+            This means more than ``total_max_jobs`` could be created, as long as the cumulative iterations
+            (summed over all created jobs) do not exceed ``max_iteration_per_job * total_max_jobs``.
+        :param pool_period_min: Time between two consecutive pools (minutes).
+        :param min_iteration_per_job: Minimum number of iterations (of the Objective metric) per single job,
+            before early stopping the job.
+        :param time_limit_per_job: Maximum execution time per single job in minutes.
+            When the time limit is exceeded, the job is aborted.
+        :param compute_time_limit: Maximum compute time in minutes.
+            When the time limit is exceeded, all jobs are aborted.
+        :param optuna_sampler: Optuna sampler instance (for example, an instance of
+            ``optuna.samplers.TPESampler``) used to control how new configurations are proposed.
+            If ``None`` (default), Optuna's own default sampler is used.
+        :param optuna_pruner: Optuna pruner instance (for example, an instance of
+            ``optuna.pruners.MedianPruner``) used to decide whether to prune (early-stop) an unpromising trial.
+            If ``None`` (default), Optuna's own default pruner is used.
+        :param optuna_kwargs: Arguments passed directly to the Optuna object.
         """
         super(OptimizerOptuna, self).__init__(
             base_task_id=base_task_id,
@@ -196,12 +203,11 @@ class OptimizerOptuna(SearchStrategy):
 
     def start(self) -> None:
         """
-        Start the Optimizer controller function loop()
-        If the calling process is stopped, the controller will stop as well.
+        Start the optimizer controller's function loop. If the calling process is stopped, the controller will
+        stop as well.
 
         .. important::
-            This function returns only after optimization is completed or :meth:`stop` was called.
-
+            This function returns only after the optimization is completed or ```stop``` is called.
         """
         if self._objective_metric.len != 1:
             self._study = optuna.create_study(
@@ -239,8 +245,8 @@ class OptimizerOptuna(SearchStrategy):
 
     def stop(self) -> None:
         """
-        Stop the current running optimization loop,
-        Called from a different thread than the :meth:`start`.
+        Stop the current running optimization loop. Should be called from a different thread than the one
+        running :meth:`start`.
         """
         if self._study:
             try:

--- a/clearml/automation/parameters.py
+++ b/clearml/automation/parameters.py
@@ -109,7 +109,7 @@ class Parameter(RandomSeed):
 
 class UniformParameterRange(Parameter):
     """
-    Uniform randomly sampled hyperparameter object.
+    Uniformly randomly sampled hyperparameter object.
     """
 
     def __init__(
@@ -121,18 +121,14 @@ class UniformParameterRange(Parameter):
         include_max_value: bool = True,
     ):
         """
-        Create a parameter to be sampled by the SearchStrategy
+        Create a parameter to be sampled by the SearchStrategy.
 
-        :param str name: The parameter name. Match the Task hyperparameter name.
-        :param float min_value: The minimum sample to use for uniform random sampling.
-        :param float max_value: The maximum sample to use for uniform random sampling.
-        :param float step_size: If not ``None``, set step size (quantization) for value sampling.
-        :param bool include_max_value: Range includes the ``max_value``.
-            The values are:
-
-          - ``True`` - The range includes the ``max_value`` (Default)
-          - ``False`` -  Does not include.
-
+        :param name: The parameter name. Match the Task hyperparameter name.
+        :param min_value: The minimum sample to use for uniform random sampling.
+        :param max_value: The maximum sample to use for uniform random sampling.
+        :param step_size: If not ``None``, quantize the sampled value to this step size.
+            If ``None`` (default), sample continuously.
+        :param include_max_value: If ``True`` (default), the range includes ``max_value``. If ``False``, it does not.
         """
         super(UniformParameterRange, self).__init__(name=name)
         self.min_value = float(min_value)
@@ -153,10 +149,10 @@ class UniformParameterRange(Parameter):
 
     def to_list(self) -> Sequence[Mapping[str, float]]:
         """
-        Return a list of all the valid values of the Parameter. If ``self.step_size`` is not defined, return 100 points
+        Return a list of all the valid values of the Parameter. If ``step_size`` is not defined, return 100 points
         between min/max values.
 
-        :return: list of dicts ``{name: float}``
+        :return: A list of dicts ``{name: float}``, each mapping the parameter name to a ``float`` value.
         """
         step_size = self.step_size or (self.max_value - self.min_value) / 100.0
         steps = (self.max_value - self.min_value) / step_size
@@ -221,7 +217,7 @@ class LogUniformParameterRange(UniformParameterRange):
 
 class UniformIntegerParameterRange(Parameter):
     """
-    Uniform randomly sampled integer Hyperparameter object.
+    Uniformly randomly sampled integer hyperparameter object.
     """
 
     def __init__(
@@ -235,16 +231,11 @@ class UniformIntegerParameterRange(Parameter):
         """
         Create a parameter to be sampled by the SearchStrategy.
 
-        :param str name: The parameter name. Match the task hyperparameter name.
-        :param int min_value: The minimum sample to use for uniform random sampling.
-        :param int max_value: The maximum sample to use for uniform random sampling.
-        :param int step_size: The default step size is ``1``.
-        :param bool include_max_value: Range includes the ``max_value``.
-            The values are:
-
-          - ``True`` - Includes the ``max_value`` (Default)
-          - ``False`` - Does not include.
-
+        :param name: The parameter name. Match the task hyperparameter name.
+        :param min_value: The minimum sample to use for uniform random sampling.
+        :param max_value: The maximum sample to use for uniform random sampling.
+        :param step_size: Step size between sampled values. Default: ``1``.
+        :param include_max_value: If ``True`` (default), the range includes ``max_value``. If ``False``, it does not.
         """
         super(UniformIntegerParameterRange, self).__init__(name=name)
         self.min_value = int(min_value)
@@ -268,10 +259,10 @@ class UniformIntegerParameterRange(Parameter):
 
     def to_list(self) -> Sequence[Mapping[str, int]]:
         """
-        Return a list of all the valid values of the Parameter. If ``self.step_size`` is not defined, return 100 points
-        between minmax values.
+        Return a list of all the valid values of the Parameter, stepping from ``min_value`` to ``max_value``
+        by ``step_size``.
 
-        :return: list of dicts ``{name: int}``
+        :return: A list of dicts ``{name: int}``, each mapping the parameter name to an ``int`` value.
         """
         values = list(range(self.min_value, self.max_value, self.step_size))
         if self.include_max and (not values or values[-1] < self.max_value):
@@ -281,15 +272,15 @@ class UniformIntegerParameterRange(Parameter):
 
 class DiscreteParameterRange(Parameter):
     """
-    Discrete randomly sampled hyperparameter object.
+    Discretely randomly sampled hyperparameter object.
     """
 
     def __init__(self, name: str, values: Sequence[Any] = ()):
         """
-        Uniformly sample values form a list of discrete options.
+        Uniformly sample values from a list of discrete options.
 
-        :param str name: The parameter name. Match the task hyperparameter name.
-        :param list values: The list/tuple of valid parameter values to sample from.
+        :param name: The parameter name. Match the task hyperparameter name.
+        :param values: The list/tuple of valid parameter values to sample from.
         """
         super(DiscreteParameterRange, self).__init__(name=name)
         self.values = values
@@ -306,14 +297,14 @@ class DiscreteParameterRange(Parameter):
         """
         Return a list of all the valid values of the Parameter.
 
-        :return: list of dicts ``{name: value}``
+        :return: A list of dicts ``{name: value}``, each mapping the parameter name to one of its valid values.
         """
         return [{self.name: v} for v in self.values]
 
 
 class ParameterSet(Parameter):
     """
-    Discrete randomly sampled Hyper-Parameter object.
+    A set of hyperparameter combinations, one of which is sampled uniformly at random.
     """
 
     def __init__(
@@ -321,20 +312,20 @@ class ParameterSet(Parameter):
         parameter_combinations: Sequence[Mapping[str, Union[float, int, str, Parameter]]] = (),
     ):
         """
-        Uniformly sample values form a list of discrete options (combinations) of parameters.
+        Uniformly sample values from a list of discrete combinations of parameters.
 
-        :param list parameter_combinations: The list/tuple of valid parameter combinations.
+        :param parameter_combinations: List/tuple of valid parameter combinations.
 
             For example, two combinations with three specific parameters per combination:
 
             .. code-block:: javascript
 
                [
-                 {"opt1": 10, "arg2": 20, "arg2": 30},
-                 {"opt2": 11, "arg2": 22, "arg2": 33}
+                 {"opt1": 10, "arg2": 20, "arg3": 30},
+                 {"opt1": 11, "arg2": 22, "arg3": 33}
                ]
 
-            Two complex combination each one sampled from a different range:
+            Two complex combinations, each one sampled from a different range:
 
             .. code-block:: javascript
 
@@ -348,7 +339,7 @@ class ParameterSet(Parameter):
 
     def get_value(self) -> Mapping[str, Any]:
         """
-        Return uniformly sampled value from the valid list of values.
+        Return a uniformly sampled combination from the valid list of combinations.
 
         :return: ``{self.name: random entry from self.value}``
         """
@@ -356,9 +347,9 @@ class ParameterSet(Parameter):
 
     def to_list(self) -> Sequence[Mapping[str, Any]]:
         """
-        Return a list of all the valid values of the Parameter.
+        Return a list of all the valid parameter combinations.
 
-        :return: list of dicts ``{name: value}``
+        :return: A list of dicts ``{name: value}``, each mapping every parameter name in a combination to its value.
         """
         combinations = []
         for combination in self.values:

--- a/clearml/automation/scheduler.py
+++ b/clearml/automation/scheduler.py
@@ -576,8 +576,9 @@ class BaseScheduler:
 
 class TaskScheduler(BaseScheduler):
     """
-    Task Scheduling controller.
-    Notice time-zone is ALWAYS UTC
+    A TaskScheduler launches Tasks (or calls functions) according to a set of cron-like scheduled jobs.
+
+    Notice: time-zone is always UTC.
     """
 
     _configuration_section = "schedule"
@@ -589,14 +590,14 @@ class TaskScheduler(BaseScheduler):
         force_create_task_project: Optional[str] = None,
     ) -> None:
         """
-        Create a Task scheduler service
+        Create a Task scheduler service.
 
-        :param sync_frequency_minutes: Sync task scheduler configuration every X minutes.
-            Allow to change scheduler in runtime by editing the Task configuration object
-        :param force_create_task_name: Optional, force creation of Task Scheduler service,
-            even if main Task.init already exists.
-        :param force_create_task_project: Optional, force creation of Task Scheduler service,
-            even if main Task.init already exists.
+        :param sync_frequency_minutes: Sync the scheduler configuration every X minutes. Allows changing the
+            schedule at runtime by editing the Task's configuration object.
+        :param force_create_task_name: Name to force-create the Task Scheduler service under, even if a main
+            ``Task.init()`` already exists.
+        :param force_create_task_project: Project to force-create the Task Scheduler service under, even if a main
+            ``Task.init()`` already exists.
         """
         super(TaskScheduler, self).__init__(
             sync_frequency_minutes=sync_frequency_minutes,
@@ -630,13 +631,13 @@ class TaskScheduler(BaseScheduler):
     ) -> bool:
         """
         Create a cron job-like scheduling for a pre-existing Task.
-        Notice, it is recommended to give the schedule entry a descriptive unique name,
-        if not provided, a name is randomly generated.
+        It is recommended to give the schedule entry a descriptive, unique name; if not provided,
+        one is randomly generated.
 
         When timespec parameters are specified exclusively, they define the time between task launches (see
-        `year` and `weekdays` exceptions). When multiple timespec parameters are specified, the parameter representing
-        the longest duration defines the time between task launches, and the shorter timespec parameters define specific
-        times.
+        the ``year`` and ``weekdays`` exceptions). When multiple timespec parameters are specified, the parameter
+        representing the longest duration defines the time between task launches, and the shorter timespec
+        parameters define specific times.
 
         Examples:
 
@@ -670,13 +671,13 @@ class TaskScheduler(BaseScheduler):
 
             add_task(schedule_task_id='1235', queue='default', minute=30, hour=7, day=2)
 
-        Launch every Saturday at 8:30am (notice `day=0`):
+        Launch every Saturday at 8:30am (notice ``day=0``):
 
         .. code-block:: py
 
             add_task(schedule_task_id='1235', queue='default', minute=30, hour=8, day=0, weekdays=['saturday'])
 
-        Launch every 2 hours on the weekends Saturday/Sunday (notice `day` is not passed):
+        Launch every 2 hours on the weekends Saturday/Sunday (notice ``day`` is not passed):
 
         .. code-block:: py
 
@@ -694,37 +695,40 @@ class TaskScheduler(BaseScheduler):
 
             add_task(schedule_task_id='1235', queue='default', year=1, month=3, day=4)
 
-        :param schedule_task_id: ID of Task to be cloned and scheduled for execution
-        :param schedule_function: Optional, instead of providing Task ID to be scheduled,
-            provide a function to be called. Notice the function is called from the scheduler context
-            (i.e. running on the same machine as the scheduler)
-        :param queue: Name or ID of queue to put the Task into (i.e. schedule)
-        :param name: Name or description for the cron Task (should be unique if provided, otherwise randomly generated)
-        :param target_project: Specify target project to put the cloned scheduled Task in.
-        :param minute: Time (in minutes) between task launches. If specified together with `hour`, `day`, `month`,
-            and / or  `year`, it defines the minute of the hour
-        :param hour: Time (in hours) between task launches. If specified together with `day`, `month`, and / or
-            `year`, it defines the hour of day.
-        :param day: Time (in days) between task executions. If specified together with  `month` and / or `year`,
-            it defines the day of month
+        :param schedule_task_id: ID of Task to be cloned and scheduled for execution.
+        :param schedule_function: A function to call instead of providing a Task ID to schedule. The function is
+            called from the scheduler context (i.e. runs on the same machine as the scheduler). Mutually
+            exclusive with ``schedule_task_id``.
+        :param queue: Name or ID of the queue to put the Task into (i.e. schedule it on).
+        :param name: Name or description for the cron Task (should be unique if provided, otherwise randomly
+            generated).
+        :param target_project: The project to put the cloned scheduled Task in.
+        :param minute: Time (in minutes) between task launches. If specified together with ``hour``, ``day``,
+            ``month``, and / or ``year``, it defines the minute of the hour.
+        :param hour: Time (in hours) between task launches. If specified together with ``day``, ``month``,
+            and / or ``year``, it defines the hour of day.
+        :param day: Time (in days) between task executions. If specified together with ``month`` and / or
+            ``year``, it defines the day of month.
         :param weekdays: Days of week to launch task (accepted inputs: 'monday', 'tuesday', 'wednesday',
-            'thursday', 'friday', 'saturday', 'sunday')
-        :param month: Time (in months) between task launches. If specified with `year`, it defines a specific month
+            'thursday', 'friday', 'saturday', 'sunday').
+        :param month: Time (in months) between task launches. If specified with ``year``, it defines a specific
+            month.
         :param year: Specific year if value >= current year. Time (in years) between task launches if
-            value <= 100
+            value <= 100.
         :param limit_execution_time: Limit the execution time (in hours) of the specific job.
-        :param single_instance: If True, do not launch the Task job if the previous instance is still running
-            (skip until the next scheduled time period). Default False.
-        :param recurring: If False, only launch the Task once (default: True, repeat)
-        :param execute_immediately: If True, schedule the Task to be executed immediately
-            then recurring based on the timing schedule arguments. Default False.
-        :param reuse_task: If True, re-enqueue the same Task (i.e. do not clone it) every time, default False.
-        :param task_parameters: Configuration parameters to the executed Task.
-            for example: ``{'Args/batch': '12'}`` Notice: not available when reuse_task=True
-        :param task_overrides: Change task definition.
-            for example ``{'script.version_num': None, 'script.branch': 'main'}`` Notice: not available when reuse_task=True
+        :param single_instance: If ``True``, do not launch the Task job if the previous instance is still running
+            (skip until the next scheduled time period) (default ``False``).
+        :param recurring: If ``False``, launch the Task only once instead of repeating (default ``True``).
+        :param execute_immediately: If ``True``, schedule the Task for immediate execution, then continue
+            recurring based on the timing schedule arguments (default ``False``).
+        :param reuse_task: If ``True``, re-enqueue the same Task (i.e. do not clone it) every time
+            (default ``False``).
+        :param task_parameters: Configuration parameters for the executed Task, for example:
+            ``{'Args/batch': '12'}``. Not available when ``reuse_task`` is ``True``.
+        :param task_overrides: Change the Task's definition, for example:
+            ``{'script.version_num': None, 'script.branch': 'main'}``. Not available when ``reuse_task`` is ``True``.
 
-        :return: True if job is successfully added to the scheduling list
+        :return: ``True`` if the job was successfully added to the scheduling list.
         """
         mutually_exclusive(schedule_function=schedule_function, schedule_task_id=schedule_task_id)
         task_id = schedule_task_id.id if isinstance(schedule_task_id, Task) else str(schedule_task_id or "")
@@ -758,9 +762,9 @@ class TaskScheduler(BaseScheduler):
 
     def get_scheduled_tasks(self) -> List[ScheduleJob]:
         """
-        Return the current set of scheduled jobs
+        Return the current set of scheduled jobs.
 
-        :return: List of ScheduleJob instances
+        :return: A list of ``ScheduleJob`` instances.
         """
         return self._schedule_jobs
 
@@ -768,15 +772,16 @@ class TaskScheduler(BaseScheduler):
         """
         Remove a Task ID from the scheduled task list.
 
-        :param task_id: Task or Task ID to be removed
-        :return: return True of the Task ID was found in the scheduled jobs list and was removed.
+        :param task_id: Task or Task ID to be removed.
+        :return: ``True`` if the Task ID was found in the scheduled jobs list and removed.
         """
         def get_schedule_job_task_id(schedule_job: ScheduleJob) -> Any:
             """
-            Compares the provided task_id with the scheduled job's task ID by means of equality.
-            - isinstance(task_id, Task) -> `schedule_job.base_task_id == task_id.id
-            - isinstance(task_id, str) -> `schedule_job.base_task_id == str(task_id)
-            - isinstance(task_id, Callable) (fallback case) -> `schedule_job.base_function == task_id`
+            Compare the provided ``task_id`` with the scheduled job's task ID by equality.
+
+            - ``isinstance(task_id, Task)`` -> ``schedule_job.base_task_id == task_id.id``
+            - ``isinstance(task_id, str)`` -> ``schedule_job.base_task_id == str(task_id)``
+            - ``isinstance(task_id, Callable)`` (fallback case) -> ``schedule_job.base_function == task_id``
             """
             return (
                 getattr(
@@ -811,7 +816,9 @@ class TaskScheduler(BaseScheduler):
 
     def start(self) -> None:
         """
-        Start the Task TaskScheduler loop (notice this function does not return)
+        Start the TaskScheduler loop.
+
+        Notice: this method does not return.
         """
         super(TaskScheduler, self).start()
 
@@ -874,9 +881,12 @@ class TaskScheduler(BaseScheduler):
 
     def start_remotely(self, queue: str = "services") -> None:
         """
-        Start the Task TaskScheduler loop (notice this function does not return)
+        Serialize the current scheduler state and re-launch this scheduler as a Task, enqueued on the given
+        remote queue.
 
-        :param queue: Remote queue to run the scheduler on, default 'services' queue.
+        Notice: this method does not return.
+
+        :param queue: The queue to enqueue the scheduler service on (default ``'services'``).
         """
         super(TaskScheduler, self).start_remotely(queue=queue)
 

--- a/clearml/automation/trigger.py
+++ b/clearml/automation/trigger.py
@@ -294,14 +294,14 @@ class ExecutedTrigger(ExecutedJob):
 
 class TriggerScheduler(BaseScheduler):
     """
-    Trigger Task execution if an event happens in the system.
+    A TriggerScheduler launches Tasks (or calls functions) when an event event in your ClearML system.
 
     Examples:
 
-    - New model is published/tagged,
-    - New Dataset is created,
-    - General Task failed,
-    - Task metric below/above threshold, alert every X minutes
+    - A new model is published or tagged
+    - A new Dataset is created
+    - A Task fails
+    - A Task metric goes above/below a threshold
     """
 
     _datasets_section = "datasets"
@@ -317,15 +317,15 @@ class TriggerScheduler(BaseScheduler):
         force_create_task_project: Optional[str] = None,
     ) -> None:
         """
-        Create a Task trigger service
+        Create a Task trigger service.
 
-        :param pooling_frequency_minutes: Check for new events every X minutes (default 3)
-        :param sync_frequency_minutes: Sync task scheduler configuration every X minutes.
-            Allow to change scheduler in runtime by editing the Task configuration object
-        :param force_create_task_name: Optional, force creation of Task Scheduler service,
-            even if main Task.init already exists.
-        :param force_create_task_project: Optional, force creation of Task Scheduler service,
-            even if main Task.init already exists.
+        :param pooling_frequency_minutes: Check for new events every X minutes (default ``3``).
+        :param sync_frequency_minutes: Sync the scheduler configuration every X minutes. Allows changing the
+            schedule at runtime by editing the Task's configuration object.
+        :param force_create_task_name: Name to force-create the Task Scheduler service under, even if a main
+            ``Task.init()`` already exists.
+        :param force_create_task_project: Project to force-create the Task Scheduler service under, even if a main
+            ``Task.init()`` already exists.
         """
         super(TriggerScheduler, self).__init__(
             sync_frequency_minutes=sync_frequency_minutes,
@@ -359,43 +359,43 @@ class TriggerScheduler(BaseScheduler):
         task_overrides: Optional[dict] = None,
     ) -> None:
         """
-        Create a cron job alike scheduling for a pre existing Task or function.
-        Trigger the Task/function execution on changes in the model repository
-        Notice it is recommended to give the trigger a descriptive unique name, if not provided a task ID is used.
+        Create a cron job-like scheduling for a pre-existing Task or function.
+        Trigger the Task/function execution on changes in the model repository.
+        It is recommended to give the trigger a descriptive, unique name; if not provided, a task ID is used.
 
-        Notice `task_overrides` can except reference to the trigger model ID:
-        example: ``task_overrides={'Args/model_id': '${model.id}'}``
-        Notice if schedule_function is passed, use the following function interface:
+        ``task_overrides`` can accept a reference to the trigger's model ID, for example:
+        ``task_overrides={'Args/model_id': '${model.id}'}``.
+        If ``schedule_function`` is passed, it must follow this interface:
 
         .. code-block:: py
 
             def schedule_function(model_id):
                 pass
 
-
-        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution
-        :param schedule_queue: Queue name or ID to put the Task into (i.e. schedule)
-        :param schedule_function: Optional, instead of providing Task ID to be scheduled,
-            provide a function to be called. Notice the function is called from the scheduler context
-            (i.e. running on the same machine as the scheduler)
-        :param name: Name or description for the cron Task (should be unique if provided otherwise randomly generated)
-        :param trigger_project: Only monitor models from this specific project (not recursive)
-        :param trigger_name: Trigger only on models with name matching (regexp)
+        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution.
+        :param schedule_queue: Name or ID of the queue to put the Task into (i.e. schedule it on).
+        :param schedule_function: A function to call instead of providing a Task ID to schedule. The function is
+            called from the scheduler context (i.e. runs on the same machine as the scheduler).
+        :param name: Name or description for the cron Task (should be unique if provided, otherwise randomly
+            generated).
+        :param trigger_project: Only monitor models from this specific project (not recursive).
+        :param trigger_name: Trigger only on models with name matching (regexp).
         :param trigger_on_publish: Trigger when model is published.
-        :param trigger_on_tags: Trigger when all tags in the list are present
-        :param trigger_on_archive: Trigger when model is archived
-        :param trigger_required_tags: Trigger only on models with the following additional tags (must include all tags)
-        :param target_project: Specify target project to put the cloned scheduled Task in.
-        :param add_tag: Add tag to the executed Task. Provide specific tag (str) or
-            pass True (default) to use the trigger name as tag
-        :param single_instance: If True, do not launch the Task job if the previous instance is still running
-            (skip until the next scheduled time period). Default False.
-        :param reuse_task: If True, re-enqueue the same Task (i.e. do not clone it) every time, default False.
-        :param task_parameters: Configuration parameters to the executed Task.
-            for example: ``{'Args/batch': '12'}`` Notice: not available when reuse_task=True
-        :param task_overrides: Change task definition.
-            for example ``{'script.version_num': None, 'script.branch': 'main'}`` Notice: not available when reuse_task=True
-        :return: True if job is successfully added to the scheduling list
+        :param trigger_on_tags: Trigger when all tags in the list are present.
+        :param trigger_on_archive: Trigger when model is archived.
+        :param trigger_required_tags: Trigger only on models with the following additional tags (must include
+            all tags).
+        :param target_project: The project to put the cloned scheduled Task in.
+        :param add_tag: Tag to add to the executed Task. Provide a specific tag (str), or pass ``True`` (default)
+            to use the trigger name as the tag.
+        :param single_instance: If ``True``, do not launch the Task job if the previous instance is still running
+            (skip until the next scheduled time period) (default ``False``).
+        :param reuse_task: If ``True``, re-enqueue the same Task (i.e. do not clone it) every time
+            (default ``False``).
+        :param task_parameters: Configuration parameters for the executed Task, for example:
+            ``{'Args/batch': '12'}``. Not available when ``reuse_task`` is ``True``.
+        :param task_overrides: Change the Task's definition, for example:
+            ``{'script.version_num': None, 'script.branch': 'main'}``. Not available when ``reuse_task`` is ``True``.
         """
         trigger = ModelTrigger(
             base_task_id=schedule_task_id,
@@ -438,45 +438,44 @@ class TriggerScheduler(BaseScheduler):
         task_overrides: Optional[dict] = None,
     ) -> None:
         """
-        Create a cron job alike scheduling for a pre existing Task or function.
-        Trigger the Task/function execution on changes in the dataset repository (notice this is not the hyper-datasets).
-        Notice, it is recommended to give the trigger a descriptive unique name. If not provided, a task ID is used.
+        Create a cron job-like scheduling for a pre-existing Task or function.
+        Trigger the Task/function execution on changes in the dataset repository (this does not include
+        hyper-datasets).
+        It is recommended to give the trigger a descriptive, unique name; if not provided, a task ID is used.
 
-        Notice `task_overrides` can except reference to the trigger model ID:
-        example: ``task_overrides={'Args/dataset_id': '${dataset.id}'}``.
-
-        Notice if schedule_function is passed, use the following function interface:
+        ``task_overrides`` can accept a reference to the trigger's dataset ID, for example:
+        ``task_overrides={'Args/dataset_id': '${dataset.id}'}``.
+        If ``schedule_function`` is passed, it must follow this interface:
 
         .. code-block:: py
 
             def schedule_function(dataset_id):
                 pass
 
-
-        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution
-        :param schedule_queue: Queue name or ID to put the Task into (i.e. schedule)
-        :param schedule_function: Optional, instead of providing Task ID to be scheduled,
-            provide a function to be called. Notice the function is called from the scheduler context
-            (i.e. running on the same machine as the scheduler)
-        :param name: Name or description for the cron Task (should be unique if provided otherwise randomly generated)
-        :param trigger_project: Only monitor datasets from this specific project (not recursive)
-        :param trigger_name: Trigger only on datasets with name matching (regexp)
+        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution.
+        :param schedule_queue: Name or ID of the queue to put the Task into (i.e. schedule it on).
+        :param schedule_function: A function to call instead of providing a Task ID to schedule. The function is
+            called from the scheduler context (i.e. runs on the same machine as the scheduler).
+        :param name: Name or description for the cron Task (should be unique if provided, otherwise randomly
+            generated).
+        :param trigger_project: Only monitor datasets from this specific project (not recursive).
+        :param trigger_name: Trigger only on datasets with name matching (regexp).
         :param trigger_on_publish: Trigger when dataset is published.
-        :param trigger_on_tags: Trigger when all tags in the list are present
-        :param trigger_on_archive: Trigger when dataset is archived
-        :param trigger_required_tags: Trigger only on datasets with the
-            following additional tags (must include all tags)
-        :param target_project: Specify target project to put the cloned scheduled Task in.
-        :param add_tag: Add tag to the executed Task. Provide specific tag (str) or
-            pass True (default) to use the trigger name as tag
-        :param single_instance: If True, do not launch the Task job if the previous instance is still running
-            (skip until the next scheduled time period). Default False.
-        :param reuse_task: If True, re-enqueue the same Task (i.e. do not clone it) every time, default False.
-        :param task_parameters: Configuration parameters to the executed Task.
-            For example: ``{'Args/batch': '12'}``. Notice: not available when reuse_task=True/
-        :param task_overrides: Change task definition.
-            For example ``{'script.version_num': None, 'script.branch': 'main'}``. Notice: not available when reuse_task=True
-        :return: True if job is successfully added to the scheduling list
+        :param trigger_on_tags: Trigger when all tags in the list are present.
+        :param trigger_on_archive: Trigger when dataset is archived.
+        :param trigger_required_tags: Trigger only on datasets with the following additional tags (must include
+            all tags).
+        :param target_project: The project to put the cloned scheduled Task in.
+        :param add_tag: Tag to add to the executed Task. Provide a specific tag (str), or pass ``True`` (default)
+            to use the trigger name as the tag.
+        :param single_instance: If ``True``, do not launch the Task job if the previous instance is still running
+            (skip until the next scheduled time period) (default ``False``).
+        :param reuse_task: If ``True``, re-enqueue the same Task (i.e. do not clone it) every time
+            (default ``False``).
+        :param task_parameters: Configuration parameters for the executed Task, for example:
+            ``{'Args/batch': '12'}``. Not available when ``reuse_task`` is ``True``.
+        :param task_overrides: Change the Task's definition, for example:
+            ``{'script.version_num': None, 'script.branch': 'main'}``. Not available when ``reuse_task`` is ``True``.
         """
         if trigger_project:
             trigger_project_list = Task.get_projects(
@@ -550,49 +549,56 @@ class TriggerScheduler(BaseScheduler):
         task_overrides: Optional[dict] = None,
     ) -> None:
         """
-        Create a cron job alike scheduling for a pre existing Task or function.
-        Trigger the Task/function execution on changes in the Task
-        Notice it is recommended to give the trigger a descriptive unique name, if not provided a task ID is used.
+        Create a cron job-like scheduling for a pre-existing Task or function.
+        Trigger the Task/function execution on changes to a Task.
+        It is recommended to give the trigger a descriptive, unique name; if not provided, a task ID is used.
 
-        Notice `task_overrides` can except reference to the trigger model ID:
-        example: ``task_overrides={'Args/task_id': '${task.id}'}``
-        Notice if schedule_function is passed, use the following function interface:
+        ``task_overrides`` can accept a reference to the trigger's task ID, for example:
+        ``task_overrides={'Args/task_id': '${task.id}'}``.
+        If ``schedule_function`` is passed, it must follow this interface:
 
         .. code-block:: py
 
             def schedule_function(task_id):
                 pass
 
-        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution
-        :param schedule_queue: Queue name or ID to put the Task into (i.e. schedule)
-        :param schedule_function: Optional, instead of providing Task ID to be scheduled,
-            provide a function to be called. Notice the function is called from the scheduler context
-            (i.e. running on the same machine as the scheduler)
-        :param name: Name or description for the cron Task (should be unique if provided otherwise randomly generated)
-        :param trigger_project: Only monitor tasks from this specific project (not recursive)
-        :param trigger_name: Trigger only on tasks with name matching (regexp)
-        :param trigger_on_tags: Trigger when all tags in the list are present
-        :param trigger_required_tags: Trigger only on tasks with the following additional tags (must include all tags)
-        :param trigger_on_status: Trigger on Task status change. Expect list of status strings, e.g. ['failed', 'published'].
-            TaskStatusEnum: ["created", "in_progress", "stopped", "closed", "failed", "completed", "queued", "published",
-            "publishing", "unknown"]
-        :param trigger_exclude_dev_tasks: If True only trigger on Tasks executed by clearml-agent (and not manually)
-        :param trigger_on_metric: Trigger on metric/variant above/under threshold (metric=title, variant=series)
-        :param trigger_on_variant: Trigger on metric/variant above/under threshold (metric=title, variant=series)
-        :param trigger_on_threshold: Trigger on metric/variant above/under threshold (float number)
-        :param trigger_on_sign: possible values "max"/"maximum" or "min"/"minimum",
-            trigger Task if metric below "min" or "above" maximum. Default: "minimum"
-        :param target_project: Specify target project to put the cloned scheduled Task in.
-        :param add_tag: Add tag to the executed Task. Provide specific tag (str) or
-            pass True (default) to use the trigger name as tag
-        :param single_instance: If True, do not launch the Task job if the previous instance is still running
-            (skip until the next scheduled time period). Default False.
-        :param reuse_task: If True, re-enqueue the same Task (i.e. do not clone it) every time, default False.
-        :param task_parameters: Configuration parameters to the executed Task.
-            for example: ``{'Args/batch': '12'}`` Notice: not available when reuse_task=True/
-        :param task_overrides: Change task definition.
-            for example ``{'script.version_num': None, 'script.branch': 'main'}``. Notice: not available when reuse_task=True
-        :return: True if job is successfully added to the scheduling list
+        :param schedule_task_id: Task/task ID to be cloned and scheduled for execution.
+        :param schedule_queue: Name or ID of the queue to put the Task into (i.e. schedule it on).
+        :param schedule_function: A function to call instead of providing a Task ID to schedule. The function is
+            called from the scheduler context (i.e. runs on the same machine as the scheduler).
+        :param name: Name or description for the cron Task (should be unique if provided, otherwise randomly
+            generated).
+        :param trigger_project: Only monitor tasks from this specific project (not recursive).
+        :param trigger_name: Trigger only on tasks with name matching (regexp).
+        :param trigger_on_tags: Trigger when all tags in the list are present.
+        :param trigger_required_tags: Trigger only on tasks with the following additional tags (must include
+            all tags).
+        :param trigger_on_status: Trigger on Task status change. Expects a list of status strings, e.g.
+            ``['failed', 'published']``. Valid values (``Task.TaskStatusEnum``): ``"created"``, ``"in_progress"``,
+            ``"stopped"``, ``"closed"``, ``"failed"``, ``"completed"``, ``"queued"``, ``"published"``,
+            ``"publishing"``, ``"unknown"``.
+        :param trigger_exclude_dev_tasks: If ``True``, only trigger on Tasks executed by a ``clearml-agent``
+            (not on manually-run Tasks).
+        :param trigger_on_metric: Metric title to monitor, used together with ``trigger_on_variant`` and
+            ``trigger_on_threshold``.
+        :param trigger_on_variant: Metric variant (series) to monitor, used together with ``trigger_on_metric``
+            and ``trigger_on_threshold``.
+        :param trigger_on_threshold: Threshold value (float) to trigger on, used together with
+            ``trigger_on_metric``, ``trigger_on_variant``, and ``trigger_on_sign``.
+        :param trigger_on_sign: Whether to trigger when the metric goes above or below the threshold. Pass
+            ``'max'``/``'maximum'`` to trigger when the metric rises above the threshold, or ``'min'``/``'minimum'``
+            to trigger when it falls below it (default ``'minimum'``).
+        :param target_project: The project to put the cloned scheduled Task in.
+        :param add_tag: Tag to add to the executed Task. Provide a specific tag (str), or pass ``True`` (default)
+            to use the trigger name as the tag.
+        :param single_instance: If ``True``, do not launch the Task job if the previous instance is still running
+            (skip until the next scheduled time period) (default ``False``).
+        :param reuse_task: If ``True``, re-enqueue the same Task (i.e. do not clone it) every time
+            (default ``False``).
+        :param task_parameters: Configuration parameters for the executed Task, for example:
+            ``{'Args/batch': '12'}``. Not available when ``reuse_task`` is ``True``.
+        :param task_overrides: Change the Task's definition, for example:
+            ``{'script.version_num': None, 'script.branch': 'main'}``. Not available when ``reuse_task`` is ``True``.
         """
         trigger = TaskTrigger(
             base_task_id=schedule_task_id,
@@ -621,14 +627,17 @@ class TriggerScheduler(BaseScheduler):
 
     def start(self) -> None:
         """
-        Start the Task trigger loop (notice this function does not return)
+        Start the TriggerScheduler loop.
+
+        Notice: this method does not return.
         """
         super(TriggerScheduler, self).start()
 
     def get_triggers(self) -> List[BaseTrigger]:
         """
-        Return all triggers (models, datasets, tasks)
-        :return: List of trigger objects
+        Return all triggers (models, datasets, and tasks).
+
+        :return: A list of ``BaseTrigger`` objects.
         """
         return self._model_triggers + self._dataset_triggers + self._task_triggers
 

--- a/clearml/backend_api/session/client/client.py
+++ b/clearml/backend_api/session/client/client.py
@@ -23,7 +23,6 @@ from typing import (
     Any,
 )
 
-import six
 from pathlib import Path
 
 from ... import services as api_services
@@ -44,7 +43,6 @@ def api_entity_name(service: ModuleType) -> str:
     return module_name(service).rstrip("s")
 
 
-@six.python_2_unicode_compatible
 class APIError(Exception):
     """
     Class for representing an API error.
@@ -188,7 +186,6 @@ class Response:
         return list(set(chain(super(Response, self).__dir__(), fields)) - {"response"})
 
 
-@six.python_2_unicode_compatible
 class TableResponse(Response):
     """
     Representation of result containing an array of entities

--- a/clearml/backend_interface/setupuploadmixin.py
+++ b/clearml/backend_interface/setupuploadmixin.py
@@ -1,4 +1,4 @@
-from abc import abstractproperty
+from abc import ABC, abstractmethod
 from typing import Optional
 import warnings
 
@@ -10,9 +10,16 @@ from ..backend_config.bucket_config import (
 from ..storage.helper import StorageHelper
 
 
-class SetupUploadMixin:
-    log = abstractproperty()
-    storage_uri = abstractproperty()
+class SetupUploadMixin(ABC):
+    @property
+    @abstractmethod
+    def log(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def storage_uri(self):
+        pass
 
     def setup_upload(
         self,

--- a/clearml/backend_interface/task/access.py
+++ b/clearml/backend_interface/task/access.py
@@ -1,19 +1,33 @@
+from abc import ABC, abstractmethod
 import itertools
 import operator
 
-from abc import abstractproperty
 from typing import Dict, Optional, Any
 
 from pathlib2 import Path
 
 
-class AccessMixin:
+class AccessMixin(ABC):
     """A mixin providing task fields access functionality"""
+    @property
+    @abstractmethod
+    def session(self):
+        raise NotImplementedError()
 
-    session = abstractproperty()
-    data = abstractproperty()
-    cache_dir = abstractproperty()
-    log = abstractproperty()
+    @property
+    @abstractmethod
+    def data(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def cache_dir(self):
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def log(self):
+        raise NotImplementedError()
 
     def _get_task_property(
         self,

--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -70,7 +70,7 @@ class CreateAndPopulate:
         :param task_type: Optional, The task type to be created. Supported values: 'training', 'testing', 'inference',
             'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc', 'custom'
         :param repo: Remote URL for the repository to use, OR path to local copy of the git repository
-            Example: 'https://github.com/allegroai/clearml.git' or '~/project/repo'
+            Example: 'https://github.com/clearml/clearml.git' or '~/project/repo'
         :param branch: Select specific repository branch/tag (implies the latest commit from the branch)
         :param commit: Select specific commit id to use (default: latest commit,
             or when used with local repository matching the local commit id)
@@ -851,7 +851,7 @@ if __name__ == '__main__':
         :param auto_connect_frameworks: Control the frameworks auto connect, see `Task.init` auto_connect_frameworks
         :param auto_connect_arg_parser: Control the ArgParser auto connect, see `Task.init` auto_connect_arg_parser
         :param repo: Remote URL for the repository to use, OR path to local copy of the git repository
-            Example: 'https://github.com/allegroai/clearml.git' or '~/project/repo'
+            Example: 'https://github.com/clearml/clearml.git' or '~/project/repo'
         :param branch: Select specific repository branch/tag (implies the latest commit from the branch)
         :param commit: Select specific commit id to use (default: latest commit,
             or when used with local repository matching the local commit id)

--- a/clearml/hyperdatasets/core.py
+++ b/clearml/hyperdatasets/core.py
@@ -41,19 +41,22 @@ class HyperDataset(HyperDatasetManagement):
         raise_if_exists: bool = False,
         **kwargs,
     ):
-        """Create a new HyperDataset version within the requested project.
+        """
+        Create a new HyperDataset version within the requested project.
 
-        :param project_name: ClearML project name that will own the dataset
-        :param dataset_name: HyperDataset collection name (top-level dataset)
-        :param version_name: Version name to create (or reuse if it already exists)
-        :param description: Optional dataset description string
-        :param parent_id: Optional parent dataset version IDs to link
-        :param parent_ids: (Deprecated) Optional list of parent dataset version IDs to link.
-            Only one parent ID by hyperdataset is supported. Use `parent_id` instead.
-        :param field_mappings: Optional mapping that defines vector-capable metadata fields.
+        :param project_name: ClearML project name that will own the dataset.
+        :param dataset_name: HyperDataset collection name (top-level dataset).
+        :param version_name: Version name to create (or reuse if it already exists).
+        :param description: Description for the dataset.
+        :param parent_id: Parent dataset version ID to link.
+        :param parent_ids: (Deprecated) List of parent dataset version IDs to link.
+            Only one parent ID per hyperdataset is supported. Use ``parent_id`` instead.
+        :param field_mappings: Mapping that defines vector-capable metadata fields.
             Provide the fully-qualified frame metadata path (e.g. ``meta.my_vector``) and
             the corresponding field settings accepted by the ClearML backend / Elasticsearch
-            dense vector type. For example::
+            dense vector type. For example:
+
+            .. code-block:: py
 
                 field_mappings = {
                     "meta.qa_vector": {
@@ -65,7 +68,7 @@ class HyperDataset(HyperDatasetManagement):
 
             When supplied, ClearML Server >= 3.25 is required and vector dimensions are
             validated on every frame ingest or update.
-        :param raise_if_exists: Reserved flag for compatibility (currently unused)
+        :param raise_if_exists: Reserved flag for compatibility (currently unused).
         """
         Session.verify_feature_set("advanced")
         self._project_name = project_name
@@ -113,21 +116,25 @@ class HyperDataset(HyperDatasetManagement):
         Upload and register a collection of data entries into the HyperDataset version.
         Successful registrations automatically trigger a commit to refresh the version statistics.
 
-        :param data_entries: Sequence of `DataEntry` instances to register
-        :param upload_local_files_destination: Optional storage URI for uploading local sources
-        :param batch_size: Number of entries per backend registration batch
-        :param max_workers: Maximum number of threads for upload work
-        :param show_progress: Reserved for API compatibility (no progress emitted currently)
-        :param upload_retries: Number of upload retry attempts per file
-        :param force_upload: Upload even when hashes indicate the source already exists
+        :param data_entries: Sequence of ``DataEntry`` instances to register.
+        :param upload_local_files_destination: Storage URI for uploading local sources.
+        :param batch_size: Number of entries per backend registration batch.
+        :param max_workers: Maximum number of threads for upload work.
+        :param show_progress: Reserved for API compatibility (no progress emitted currently).
+        :param upload_retries: Number of upload retry attempts per file.
+        :param force_upload: If ``True``, upload sources even when their hash indicates they already exist
+            on the backend. If ``False`` (default), sources already present on the backend are not
+            re-uploaded.
         :param max_request_size_mb: Upper bound for registration request payload size, in MB
             (default 100). Registration batches whose payload exceeds this size are split into
             multiple requests. A single entry larger than this limit is sent in its own request.
-            Pass `None` (or 0) to disable splitting and send each batch as a single request
-            regardless of its payload size
-        :param hash_sources: Whether to hash sources for deduplication prior to upload
+            Pass ``None`` (or 0) to disable splitting and send each batch as a single request
+            regardless of its payload size.
+        :param hash_sources: If ``True``, compute hashes of local sources before upload so they can be
+            deduplicated. If ``False`` (default), sources are not hashed.
 
-        :return: Dictionary containing upload and registration error mappings
+        :return: A dictionary with ``upload`` and ``register`` keys, each mapping entry IDs to the error
+            raised for that entry (empty on success).
         """
         HyperDataset._verify_upload_destination(upload_local_files_destination)
         errors = {"upload": {}, "register": {}}
@@ -168,27 +175,28 @@ class HyperDataset(HyperDatasetManagement):
         """
         Delete data entries (frames) from this HyperDataset version.
 
-        Entries may be passed as `DataEntry` objects (for example, objects yielded by
-        `get_iterator()`) or as entry id strings. Entries are deleted by their ids;
+        Entries may be passed as ``DataEntry`` objects (for example, objects yielded by
+        ``get_iterator()``) or as entry ID strings. Entries are deleted by their IDs;
         all other attributes are ignored.
 
         .. note:: Only writable (non-published) versions can delete their entries.
 
-        :param data_entries: Sequence of `DataEntry` instances and/or entry id strings
-        :param batch_size: Number of entry ids sent per delete request (default 1000).
-            It does not limit the number of entries per call
-        :param refresh_version_stats: Commit the version after deleting to refresh its
-            statistics (default True)
-        :param force: Ignore ongoing annotation tasks using this version as input
+        :param data_entries: Sequence of ``DataEntry`` instances and/or entry ID strings.
+        :param batch_size: Number of entry IDs sent per delete request (default 1000).
+            It does not limit the number of entries per call.
+        :param refresh_version_stats: If ``True`` (default), commit the version after deleting to refresh
+            its statistics. If ``False``, skip the commit.
+        :param force: If ``True``, delete the entries even if there are ongoing annotation tasks using this
+            version as input. If ``False`` (default), such tasks may prevent the deletion.
 
-        :return: Total number of entries the backend reports as deleted
+        :return: The total number of entries the backend reports as deleted.
         """
         entry_ids = []
         for data_entry in data_entries:
             entry_id = data_entry if isinstance(data_entry, str) else getattr(data_entry, "id", None)
             if not entry_id or not isinstance(entry_id, str):
                 raise ValueError(
-                    f"delete_data_entries expects DataEntry objects or entry id strings, got {data_entry!r}"
+                    f"delete_data_entries expects DataEntry objects or entry ID strings, got {data_entry!r}"
                 )
             entry_ids.append(entry_id)
 
@@ -216,9 +224,9 @@ class HyperDataset(HyperDatasetManagement):
         The supplied dictionary replaces any previously stored metadata.
 
         :param metadata: Key/value dictionary (with support for nested dictionaries).
-            Keys must not include '$' and '.'
+            Keys must not include ``$`` or ``.``.
 
-        :return: True if successful (locked/published versions cannot change version metadata)
+        :return: ``True`` if successful. Locked or published versions cannot change their version metadata.
         """
         if not isinstance(metadata, dict):
             raise ValueError("set_metadata expects a key/value dictionary")
@@ -237,7 +245,7 @@ class HyperDataset(HyperDatasetManagement):
 
         The metadata is fetched from the backend on every call.
 
-        :return: Metadata dictionary; empty when none was set
+        :return: Metadata dictionary; empty when none was set.
         """
         if not getattr(self, "_version_id", None) or not getattr(self, "_dataset_id", None):
             raise ValueError("HyperDataset instance is not bound to a dataset version")
@@ -255,20 +263,20 @@ class HyperDataset(HyperDatasetManagement):
         """
         Return an iterator over all the data entries (frames) of this HyperDataset version.
 
-        This is a convenience wrapper around a single-query `DataView` pinned to this
-        version: entries stream through the same iteration pipeline as DataView
-        iteration (background prefetching, entry-class conversion), but no DataView
+        This is a convenience wrapper around a single-query ``DataView`` pinned to this
+        version: entries stream through the same iteration pipeline as ``DataView``
+        iteration (background prefetching, entry-class conversion), but no ``DataView``
         object is persisted on the server and no Task is attached.
 
-        For filtered, weighted, or multi-version iteration, build a `DataView` instead.
+        For filtered, weighted, or multi-version iteration, build a ``DataView`` instead.
 
-        :param projection: Optional list of frame fields to return, using dot-separated
+        :param projection: List of frame fields to return, using dot-separated
             notation (for example ``["id", "sources"]``). When set, entries are
             reconstructed from the projected fields only — non-projected fields are
-            missing from the returned objects
-        :param batch_size: Optional number of entries fetched per backend request
+            missing from the returned objects.
+        :param batch_size: Number of entries fetched per backend request.
 
-        :return: Iterator yielding `DataEntry`-derived objects
+        :return: Iterator yielding ``DataEntry``-derived objects.
         """
         if not getattr(self, "_version_id", None) or not getattr(self, "_dataset_id", None):
             raise ValueError("HyperDataset instance is not bound to a dataset version")
@@ -325,7 +333,7 @@ class HyperDataset(HyperDatasetManagement):
         :param data_entries: Sequence of data entries to register
         :param max_request_size_mb: Maximum request size (MB); `None` disables batching
 
-        :return: Mapping of entry ids to registration errors
+        :return: Mapping of entry IDs to registration errors
         """
         if max_request_size_mb is not None:
             request_fixed_size = len(
@@ -411,7 +419,7 @@ class HyperDataset(HyperDatasetManagement):
 
         :param data_entries: Iterable of data entries to register
 
-        :return: Mapping of entry ids to registration errors
+        :return: Mapping of entry IDs to registration errors
         """
         if not data_entries:
             return {}
@@ -451,7 +459,7 @@ class HyperDataset(HyperDatasetManagement):
         :param hash_sources: Whether to compute hashes before upload for deduplication
         :param thread_pool: Thread pool used for concurrent uploads
 
-        :return: Mapping of entry ids to upload errors
+        :return: Mapping of entry IDs to upload errors
         """
         hash_batch_size = min(hash_batch_size, HyperDataset.MAX_HASH_FETCH_BATCH_SIZE)
 
@@ -792,16 +800,18 @@ class HyperDataset(HyperDatasetManagement):
         """
         Pythonic alternative to ``dataset.set_tags(tags=[...])``.
 
-        :param tags: The list of tags to set on the dataset (before normalization; see _normalize_tags method).
+        :param tags: Tags to set on the dataset. Accepts a single space-separated string, or a sequence
+            of tag strings.
         """
         self.set_tags(tags=(tags or []))
 
     def get_tags(self, reload: bool = False) -> List[str]:
         """
-        Returns tags attached to the dataset. Allows invalidating tags cache via ``dataset.get_tags(reload=True)``.
+        Return the tags attached to the dataset. Allows invalidating the tags cache via
+        ``dataset.get_tags(reload=True)``.
 
-        :param reload: If set to ``True``, tags will be fetched from the backend
-            and the local runtime cache will be updated.
+        :param reload: If ``True``, fetch tags from the backend and update the local runtime cache
+            (default ``False``).
 
         :return: The list of tags attached to this dataset.
         """
@@ -820,9 +830,10 @@ class HyperDataset(HyperDatasetManagement):
 
     def add_tags(self, tags: TagsInputValue) -> None:
         """
-        Adds the provided tags to the list of tags attached to the dataset.
+        Add the provided tags to the dataset.
 
-        :param tags: The list of tags to add to the dataset (before normalization; see _normalize_tags method).
+        :param tags: Tags to add to the dataset. Accepts a single space-separated string, or a sequence
+            of tag strings.
         """
         tags_to_add = self._normalize_tags(tags=tags)
         new_tags = list(set((
@@ -837,9 +848,10 @@ class HyperDataset(HyperDatasetManagement):
 
     def remove_tags(self, tags: TagsInputValue) -> None:
         """
-        Removes the provided tags from the list of tags attached to the dataset.
+        Remove the provided tags from the dataset.
 
-        :param tags: The list of tags to remove from the dataset (before normalization; see _normalize_tags method).
+        :param tags: Tags to remove from the dataset. Accepts a single space-separated string, or a sequence
+            of tag strings.
         """
         tags_to_remove = self._normalize_tags(tags=tags)
         new_tags = [
@@ -855,9 +867,10 @@ class HyperDataset(HyperDatasetManagement):
 
     def set_tags(self, tags: TagsInputValue) -> None:
         """
-        Overrides the existing tags on the dataset with the provided list of tags.
+        Override the dataset's existing tags with the provided tags.
 
-        :param tags: The list of tags that will be on the dataset (before normalization; see _normalize_tags method).
+        :param tags: Tags to set on the dataset. Accepts a single space-separated string, or a sequence
+            of tag strings.
         """
         new_tags = self._normalize_tags(tags=tags)
         HyperDatasetManagementBackend.update_dataset_tags(
@@ -885,10 +898,11 @@ class HyperDataset(HyperDatasetManagement):
 
     def create_snapshot(self) -> "HyperDataset":
         """
-        Publish a snapshot hyperdataset with parent equal to this hyperdataset.
-        Leaves this hyperdataset unchanged.
+        Publish the current version of this ``HyperDataset`` as an immutable snapshot, then continue
+        working on a new child version. This instance is updated in place to point to the new child
+        version.
 
-        :return: A new HyperDataset bound to the newly created (current) child version
+        :return: A new ``HyperDataset`` instance bound to the published snapshot version.
         """
         new_version_id = HyperDatasetManagementBackend.publish_and_create_child_version(
             dataset_id=self.dataset_id,

--- a/clearml/hyperdatasets/data_entry.py
+++ b/clearml/hyperdatasets/data_entry.py
@@ -99,8 +99,8 @@ class DataEntry:
         """
         Container for a logical frame composed of one or more sub-entries.
 
-        :param data_entry_id: Explicit entry identifier to reuse
-        :param metadata: Optional metadata dictionary stored on the frame
+        :param data_entry_id: Explicit entry identifier to reuse.
+        :param metadata: Metadata dictionary stored on the frame.
         """
         self._id = data_entry_id or uuid.uuid4().hex
         self._sub_entries: Dict[str, "DataSubEntry"] = {}
@@ -111,7 +111,7 @@ class DataEntry:
         """
         Attach the provided sub-entry objects, indexed by their name.
 
-        :param sub_entries: Iterable of sub-entry instances to register
+        :param sub_entries: Iterable of sub-entry instances to register.
         """
         self._sub_entries.update({sub_entry.name: sub_entry for sub_entry in sub_entries})
 
@@ -138,11 +138,11 @@ class DataEntry:
         """
         Attach a metadata-only annotation to this entry.
 
-        :param id: Identifier associated with this annotation
-        :param labels: Sequence of labels to associate with the annotation
-        :param confidence: Optional confidence value
-        :param metadata: Additional metadata to store alongside the annotation
-        :return: Numeric index of the appended annotation
+        :param id: Identifier associated with this annotation.
+        :param labels: Sequence of labels to associate with the annotation.
+        :param confidence: Optional confidence value.
+        :param metadata: Additional metadata to store alongside the annotation.
+        :return: Numeric index of the appended annotation.
         """
         roi: Dict[str, Any] = {}
         if labels:
@@ -161,9 +161,9 @@ class DataEntry:
         """
         Remove a single annotation by numeric index or identifier.
 
-        :param index: Annotation index to remove
-        :param kwargs: Alternative filters such as id=...
-        :return: Removed annotation payload or None when nothing matched
+        :param index: Annotation index to remove.
+        :param kwargs: Alternative filters such as ``id=...``.
+        :return: Removed annotation payload, or ``None`` when nothing matched.
         """
         if not self._annotations:
             return None
@@ -185,12 +185,12 @@ class DataEntry:
         labels: Optional[Sequence[str]] = None,
     ) -> Sequence[Any]:
         """
-        Remove annotations that match the provided id or label filters.
+        Remove annotations that match the provided ID or label filters.
 
-        :param id: Annotation identifier to match
-        :param label: Single label to match
-        :param labels: Sequence of labels to match
-        :return: Sequence of removed annotation payloads
+        :param id: Annotation identifier to match.
+        :param label: Single label to match.
+        :param labels: Sequence of labels to match.
+        :return: Sequence of removed annotation payloads.
         """
         if not self._annotations:
             return []
@@ -215,7 +215,7 @@ class DataEntry:
         """
         Return all annotations attached to this entry.
 
-        :return: Sequence of annotation payloads
+        :return: Sequence of annotation payloads.
         """
         return list(self._annotations)
 
@@ -223,9 +223,9 @@ class DataEntry:
         """
         Return annotations matching the supplied identifier/index filters.
 
-        :param id: Annotation identifier to filter by
-        :param index: Annotation index to fetch
-        :return: Sequence of matching annotation payloads
+        :param id: Annotation identifier to filter by.
+        :param index: Annotation index to fetch.
+        :return: Sequence of matching annotation payloads.
         """
         anns = list(self._annotations)
         if index is not None:
@@ -241,7 +241,7 @@ class DataEntry:
         """
         Serialize this entry to the SaveFramesRequest frame schema.
 
-        :return: Frame dictionary ready for backend submission
+        :return: Frame dictionary ready for backend submission.
         """
         meta: Dict[str, Any] = _copy_without_keys(self._metadata, ENTRY_CLASS_KEY)
         meta[ENTRY_CLASS_KEY] = _get_class_identifier(self)
@@ -291,7 +291,7 @@ class DataEntry:
         """
         Return the entry identifier used by the backend.
 
-        :return: Entry identifier string
+        :return: Entry identifier string.
         """
         return self._id
 
@@ -300,7 +300,7 @@ class DataEntry:
         """
         Return the list of attached sub-entries.
 
-        :return: List of sub-entry objects
+        :return: A list of ``DataSubEntry`` objects.
         """
         return list(self._sub_entries.values())
 
@@ -393,13 +393,12 @@ class DataSubEntry:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
-        Initialise a base sub-entry that stores source URIs and optional metadata.
+        Create a base sub-entry that stores source URIs and optional metadata.
 
-        :param name: Identifier of the sub-entry (unique per entry)
-        :param source: Primary source URI
-        :param preview_source: Optional preview URI
-        :param local_sources_upload_destination: Upload target used when auto-uploading
-        :param metadata: Optional metadata dictionary stored alongside the sub-entry
+        :param name: Identifier of the sub-entry (unique per entry).
+        :param source: Primary source URI.
+        :param preview_source: Preview URI.
+        :param metadata: Metadata dictionary stored alongside the sub-entry.
         """
         self._name = name
         self._source = source
@@ -413,8 +412,8 @@ class DataSubEntry:
         """
         Return the cached SHA256 hash for the requested source field.
 
-        :param source_field: Either "source" or "preview_source"
-        :return: Hex digest string when available, otherwise None
+        :param source_field: Either ``"source"`` or ``"preview_source"``.
+        :return: Hex digest string when available, otherwise ``None``.
         """
         if source_field == "source":
             return self._source_hash
@@ -426,8 +425,8 @@ class DataSubEntry:
         """
         Return the URI associated with the requested source field.
 
-        :param source_field: Either "source" or "preview_source"
-        :return: URI string when set, otherwise None
+        :param source_field: Either ``"source"`` or ``"preview_source"``.
+        :return: URI string when set, otherwise ``None``.
         """
         if source_field == "source":
             return self._source
@@ -439,8 +438,8 @@ class DataSubEntry:
         """
         Update the URI linked to the requested source field.
 
-        :param source_field: Either "source" or "preview_source"
-        :param uri: New URI to associate with the field
+        :param source_field: Either ``"source"`` or ``"preview_source"``.
+        :param uri: New URI to associate with the field.
         """
         if source_field == "source":
             self._source = uri
@@ -449,9 +448,9 @@ class DataSubEntry:
 
     def set_local_sources_upload_destination(self, local_sources_upload_destination):
         """
-        Set an upload destination for the local sources. This will be used when uploading the data entry
+        Set an upload destination for the local sources. This will be used when uploading the data entry.
 
-        :param local_sources_upload_destination: URL to the upload path
+        :param local_sources_upload_destination: URL to the upload path.
         """
         self._local_sources_upload_destination = local_sources_upload_destination
 
@@ -463,9 +462,9 @@ class DataSubEntry:
         """
         Retrieve a cached local copy of the primary source URI.
 
-        :param raise_on_error: Raise ValueError when the download fails
-        :param force_download: Refresh the cached copy even if it already exists
-        :return: Absolute path to the local copy or None on failure/when source missing
+        :param raise_on_error: Raise ``ValueError`` when the download fails.
+        :param force_download: Refresh the cached copy even if it already exists.
+        :return: Absolute path to the local copy, or ``None`` on failure/when source missing.
         """
         return self._get_local_source_for_field(
             "source",
@@ -481,9 +480,9 @@ class DataSubEntry:
         """
         Retrieve a cached local copy of the preview source URI.
 
-        :param raise_on_error: Raise ValueError when the download fails
-        :param force_download: Refresh the cached copy even if it already exists
-        :return: Absolute path to the local copy or None on failure/when preview missing
+        :param raise_on_error: Raise ``ValueError`` when the download fails.
+        :param force_download: Refresh the cached copy even if it already exists.
+        :return: Absolute path to the local copy, or ``None`` on failure/when preview missing.
         """
         return self._get_local_source_for_field(
             "preview_source",
@@ -516,9 +515,9 @@ class DataSubEntry:
     @property
     def name(self) -> str:
         """
-        Return the sub-entry identifier (per entry unique).
+        Return the sub-entry identifier (unique per entry).
 
-        :return: Sub-entry name
+        :return: Sub-entry name.
         """
         return self._name
 
@@ -527,7 +526,7 @@ class DataSubEntry:
         """
         Expose the main source URI.
 
-        :return: Source URI string or None
+        :return: Source URI string, or ``None``.
         """
         return self._source
 
@@ -536,7 +535,7 @@ class DataSubEntry:
         """
         Expose the preview URI when available.
 
-        :return: Preview URI string or None
+        :return: Preview URI string, or ``None``.
         """
         return self._preview_source
 

--- a/clearml/hyperdatasets/data_entry_image.py
+++ b/clearml/hyperdatasets/data_entry_image.py
@@ -39,17 +39,17 @@ class DataSubEntryImage(DataSubEntry):
         metadata: Optional[dict] = None,
     ) -> None:
         """
-        Initialise an image sub-entry with optional dimension, context and mask metadata.
+        Initialize an image sub-entry with optional dimension, context, and mask metadata.
 
-        :param name: Identifier of the sub-entry (defaults to image_entry_0)
-        :param source: Primary image URI
-        :param preview_source: Optional preview image URI
-        :param width: Image width in pixels
-        :param height: Image height in pixels
-        :param timestamp: Optional timestamp associated with the frame
-        :param context_id: Optional context identifier to correlate sources
-        :param masks_source: Sequence or mapping of mask URIs
-        :param metadata: Optional metadata dictionary stored alongside the sub-entry
+        :param name: Identifier of the sub-entry (defaults to ``"image_entry_0"``).
+        :param source: Primary image URI.
+        :param preview_source: Preview image URI.
+        :param width: Image width in pixels.
+        :param height: Image height in pixels.
+        :param timestamp: Timestamp associated with the frame.
+        :param context_id: Context identifier to correlate sources.
+        :param masks_source: Sequence or mapping of mask URIs.
+        :param metadata: Metadata dictionary stored alongside the sub-entry.
         """
         super(DataSubEntryImage, self).__init__(
             name=name,
@@ -72,9 +72,9 @@ class DataSubEntryImage(DataSubEntry):
     @property
     def width(self) -> Optional[int]:
         """
-        Return cached image width if known.
+        Return the cached image width, if known.
 
-        :return: Width in pixels or None when unknown
+        :return: Width in pixels, or ``None`` when unknown.
         """
         return self._width
 
@@ -83,16 +83,16 @@ class DataSubEntryImage(DataSubEntry):
         """
         Update the cached image width.
 
-        :param value: Width in pixels or None to clear the stored value
+        :param value: Width in pixels, or ``None`` to clear the stored value.
         """
         self._width = value
 
     @property
     def height(self) -> Optional[int]:
         """
-        Return cached image height if known.
+        Return the cached image height, if known.
 
-        :return: Height in pixels or None when unknown
+        :return: Height in pixels, or ``None`` when unknown.
         """
         return self._height
 
@@ -101,7 +101,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Update the cached image height.
 
-        :param value: Height in pixels or None to clear the stored value
+        :param value: Height in pixels, or ``None`` to clear the stored value.
         """
         self._height = value
 
@@ -110,7 +110,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Return the timestamp associated with this frame, if any.
 
-        :return: Timestamp value or None
+        :return: The timestamp value, or ``None`` if none is set.
         """
         return self._timestamp
 
@@ -119,7 +119,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Update the timestamp associated with the sub-entry.
 
-        :param value: Timestamp value or None to clear the stored timestamp
+        :param value: The timestamp value, or ``None`` to clear the stored timestamp.
         """
         self._timestamp = value
 
@@ -128,7 +128,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Return the context identifier used to correlate sub-entries.
 
-        :return: Context identifier string or None
+        :return: The context identifier string, or ``None``.
         """
         return self._context_id
 
@@ -137,7 +137,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Update the context identifier associated with the sub-entry.
 
-        :param value: Context identifier string or None to clear the stored value
+        :param value: The context identifier string, or ``None`` to clear the stored value.
         """
         self._context_id = value
 
@@ -145,7 +145,8 @@ class DataSubEntryImage(DataSubEntry):
         """
         Add a single mask URI and auto-number it (00, 01, 02, ...).
 
-        Returns the assigned mask id, or None if uri is falsy.
+        :param uri: The mask URI to add.
+        :return: The assigned mask ID, or ``None`` if ``uri`` is falsy.
         """
         if not uri:
             return None
@@ -163,8 +164,9 @@ class DataSubEntryImage(DataSubEntry):
         """
         Set multiple mask URIs and auto-number them (00, 01, 02, ...).
 
-        For dict input, the values' iteration order is used and keys are ignored.
-        For list/sequence input, order is preserved.
+        :param masks_source: A sequence of mask URIs, or a mapping of mask ID to URI. For a mapping, the values'
+            iteration order is used and the keys are ignored; for a sequence, order is preserved. If ``None``,
+            the mask sources are cleared.
         """
         if masks_source is None:
             self._masks_source = {}
@@ -181,16 +183,16 @@ class DataSubEntryImage(DataSubEntry):
         """
         Return a copy of the mask-id to URI mapping.
 
-        :return: Dictionary mapping mask ids to URIs
+        :return: A dictionary mapping mask IDs to URIs.
         """
         return dict(self._masks_source)
 
     def get_mask_source(self, mask_id: Optional[str] = None) -> Optional[str]:
         """
-        Return the URI for the requested mask id (or the first mask if omitted).
+        Return the URI for the requested mask ID (or the first mask if omitted).
 
-        :param mask_id: Mask identifier (e.g. "00")
-        :return: Mask URI string or None when unavailable
+        :param mask_id: Mask identifier (e.g. ``"00"``).
+        :return: The mask URI string, or ``None`` when unavailable.
         """
         if not self._masks_source:
             return None
@@ -208,10 +210,11 @@ class DataSubEntryImage(DataSubEntry):
         """
         Retrieve a cached local copy of a specific mask source.
 
-        :param raise_on_error: Raise ValueError when the download fails
-        :param mask_id: Mask identifier to fetch; defaults to the first mask
-        :param force_download: Refresh an existing cached entry when True
-        :return: Absolute path to the local copy or None when unavailable
+        :param raise_on_error: If ``True``, raise ``ValueError`` when the download fails (default ``False``).
+        :param mask_id: Mask identifier to fetch; defaults to the first mask.
+        :param force_download: If ``True``, refresh an existing cached entry instead of reusing it
+            (default ``False``).
+        :return: The absolute path to the local copy, or ``None`` when unavailable.
         """
         uri = self.get_mask_source(mask_id)
         if not uri:
@@ -237,9 +240,11 @@ class DataSubEntryImage(DataSubEntry):
         """
         Retrieve cached local copies for all mask sources on this sub-entry.
 
-        :param raise_on_error: Raise ValueError when any download fails
-        :param force_download: Refresh existing cached entries when True
-        :return: Mapping of mask id to the local copy path (or None on failure if raise_on_error is False)
+        :param raise_on_error: If ``True``, raise ``ValueError`` when any download fails (default ``False``).
+        :param force_download: If ``True``, refresh existing cached entries instead of reusing them
+            (default ``False``).
+        :return: A mapping of mask ID to local copy path (``None`` for a given mask if its download fails and
+            ``raise_on_error`` is ``False``).
         """
         masks: Dict[str, Optional[str]] = {}
         for mid, uri in sorted((self._masks_source or {}).items()):
@@ -291,20 +296,20 @@ class DataSubEntryImage(DataSubEntry):
         """
         Create ROI records for this sub-entry and return their indices.
 
-        :param poly2d_xy: 2D polygon coordinates
-        :param poly3d_xyz: 3D polygon coordinates
-        :param points2d_xy: 2D keypoint coordinates
-        :param points3d_xyz: 3D keypoint coordinates
-        :param box2d_xywh: 2D bounding box definition
-        :param box3d_xyzwhxyzwh: 3D bounding box definition
-        :param ellipse2d_xyrrt: 2D ellipse definition
-        :param mask_rgb: RGB mask values
-        :param frame_class: Optional frame-level class labels
-        :param id: Annotation identifier
-        :param labels: Sequence of label names
-        :param confidence: Optional confidence value
-        :param metadata: Extra metadata mapping to attach to the annotation
-        :return: List of annotation indices that were appended
+        :param poly2d_xy: 2D polygon coordinates.
+        :param poly3d_xyz: 3D polygon coordinates.
+        :param points2d_xy: 2D keypoint coordinates.
+        :param points3d_xyz: 3D keypoint coordinates.
+        :param box2d_xywh: 2D bounding box definition.
+        :param box3d_xyzwhxyzwh: 3D bounding box definition.
+        :param ellipse2d_xyrrt: 2D ellipse definition.
+        :param mask_rgb: RGB mask values.
+        :param frame_class: Frame-level class labels.
+        :param id: Annotation identifier.
+        :param labels: Sequence of label names.
+        :param confidence: Confidence value.
+        :param metadata: Extra metadata mapping to attach to the annotation.
+        :return: A list of the indices of the annotations that were appended.
         """
         # Minimal in-memory ROI creation compatible with SaveFramesRequest schema
         anns: List[Dict[str, Any]] = []
@@ -412,9 +417,9 @@ class DataSubEntryImage(DataSubEntry):
         """
         Remove a single annotation by numeric index or identifier.
 
-        :param index: Annotation index to remove
-        :param kwargs: Alternative filters such as id=...
-        :return: Removed annotation payload or None when nothing matched
+        :param index: Annotation index to remove.
+        :param kwargs: Alternative filters, such as ``id=...``.
+        :return: The removed annotation payload, or ``None`` if nothing matched.
         """
         if not hasattr(self, "_annotations") or not self._annotations:
             return None
@@ -434,12 +439,12 @@ class DataSubEntryImage(DataSubEntry):
         self, id: Optional[str] = None, label: Optional[str] = None, labels: Optional[Sequence[str]] = None
     ) -> Sequence[Any]:
         """
-        Remove annotations that match the provided id or label filters.
+        Remove annotations that match the provided ID or label filters.
 
-        :param id: Annotation identifier to match
-        :param label: Single label to match
-        :param labels: Sequence of labels to match
-        :return: Sequence of removed annotation payloads
+        :param id: Annotation identifier to match.
+        :param label: Single label to match.
+        :param labels: Sequence of labels to match.
+        :return: A sequence of the removed annotation payloads.
         """
         if not hasattr(self, "_annotations") or not self._annotations:
             return []
@@ -464,7 +469,7 @@ class DataSubEntryImage(DataSubEntry):
         """
         Return all annotations attached to this sub-entry.
 
-        :return: Sequence of annotation payloads
+        :return: A sequence of the annotation payloads attached to this sub-entry.
         """
         return list(getattr(self, "_annotations", []) or [])
 
@@ -472,9 +477,9 @@ class DataSubEntryImage(DataSubEntry):
         """
         Return annotations matching the supplied identifier/index filters.
 
-        :param id: Annotation identifier to filter by
-        :param index: Annotation index to fetch
-        :return: Sequence of matching annotation payloads
+        :param id: Annotation identifier to filter by.
+        :param index: Annotation index to fetch.
+        :return: A sequence of the matching annotation payloads.
         """
         anns = list(getattr(self, "_annotations", []) or [])
         if index is not None:
@@ -560,20 +565,20 @@ class DataEntryImage(DataEntry):
         """
         Broadcast an annotation request to all sub-entries and aggregate their indices.
 
-        :param poly2d_xy: 2D polygon coordinates
-        :param poly3d_xyz: 3D polygon coordinates
-        :param points2d_xy: 2D keypoint coordinates
-        :param points3d_xyz: 3D keypoint coordinates
-        :param box2d_xywh: 2D bounding box definition
-        :param box3d_xyzwhxyzwh: 3D bounding box definition
-        :param ellipse2d_xyrrt: 2D ellipse definition
-        :param mask_rgb: RGB mask values
-        :param frame_class: Optional frame-level class labels
-        :param id: Annotation identifier
-        :param labels: Sequence of label names
-        :param confidence: Optional confidence value
-        :param metadata: Extra metadata mapping to attach to the annotation
-        :return: List of annotation indices returned by the sub-entries
+        :param poly2d_xy: 2D polygon coordinates.
+        :param poly3d_xyz: 3D polygon coordinates.
+        :param points2d_xy: 2D keypoint coordinates.
+        :param points3d_xyz: 3D keypoint coordinates.
+        :param box2d_xywh: 2D bounding box definition.
+        :param box3d_xyzwhxyzwh: 3D bounding box definition.
+        :param ellipse2d_xyrrt: 2D ellipse definition.
+        :param mask_rgb: RGB mask values.
+        :param frame_class: Frame-level class labels.
+        :param id: Annotation identifier.
+        :param labels: Sequence of label names.
+        :param confidence: Confidence value.
+        :param metadata: Extra metadata mapping to attach to the annotation.
+        :return: A list of the annotation indices returned by the sub-entries.
         """
         idxs: List[int] = []
         for sub in (self.sub_data_entries or []):
@@ -601,9 +606,9 @@ class DataEntryImage(DataEntry):
         """
         Remove the first matching annotation across sub-entries.
 
-        :param index: Annotation index to remove
-        :param kwargs: Alternative filters such as id=...
-        :return: Removed annotation payload or None when nothing matched
+        :param index: Annotation index to remove.
+        :param kwargs: Alternative filters, such as ``id=...``.
+        :return: The removed annotation payload, or ``None`` if nothing matched.
         """
         removed = None
         for sub in (self.sub_data_entries or []):
@@ -617,10 +622,10 @@ class DataEntryImage(DataEntry):
         """
         Remove annotations across sub-entries using the provided filters.
 
-        :param id: Annotation identifier to match
-        :param label: Single label to match
-        :param labels: Sequence of labels to match
-        :return: Sequence of removed annotation payloads
+        :param id: Annotation identifier to match.
+        :param label: Single label to match.
+        :param labels: Sequence of labels to match.
+        :return: A sequence of the removed annotation payloads.
         """
         removed: List[Any] = []
         for sub in (self.sub_data_entries or []):
@@ -632,7 +637,7 @@ class DataEntryImage(DataEntry):
         """
         Return every annotation collected from all sub-entries.
 
-        :return: Sequence of annotation payloads across all sub-entries
+        :return: A sequence of the annotation payloads collected from all sub-entries.
         """
         anns: List[Any] = []
         for sub in (self.sub_data_entries or []):
@@ -647,9 +652,9 @@ class DataEntryImage(DataEntry):
         """
         Return global annotations filtered by identifier or index.
 
-        :param id: Annotation identifier to filter by
-        :param index: Annotation index to fetch
-        :return: Sequence of matching annotation payloads
+        :param id: Annotation identifier to filter by.
+        :param index: Annotation index to fetch.
+        :return: A sequence of the matching annotation payloads.
         """
         if id is None and index is None:
             return self.get_all_global_annotations()
@@ -720,7 +725,7 @@ class DataEntryImage(DataEntry):
     @classmethod
     def from_api_object(cls, frame: Any) -> "DataEntryImage":
         """
-        Convert backend frame (dict/object) to DataEntryImage + DataSubEntryImage tree.
+        Convert a backend frame (dict or object) into a ``DataEntryImage`` and its ``DataSubEntryImage`` tree.
         """
         log = logging.getLogger("DataView")
 

--- a/clearml/hyperdatasets/data_view.py
+++ b/clearml/hyperdatasets/data_view.py
@@ -88,20 +88,22 @@ class HyperDatasetQuery:
         filter_by_roi: Optional[Any] = None,  # Optional[FilterByRoiEnum]
         label_rules: Optional[Any] = None,  # Optional[Sequence[dataviews.FilterLabelRule]]
     ):
-        """Construct a hyper-dataset query filter.
+        """
+        Construct a hyper-dataset query filter.
 
-        When concrete dataset/version IDs are supplied the constructor verifies their existence via
-        `HyperDatasetManagement`. Optional Lucene queries, ROI filtering, and sampling weights can be
+        When concrete dataset/version IDs are supplied, the constructor verifies their existence via
+        ``HyperDatasetManagement``. Lucene queries, ROI filtering, and sampling weights can be
         provided to further refine the query.
 
-        :param project_id: Dataset collection identifier or wildcard
-        :param dataset_id: Dataset identifier or wildcard (legacy) used when version is omitted
-        :param version_id: Dataset version identifier; defaults to `dataset_id` when empty
-        :param source_query: Lucene query applied to frame source metadata
-        :param frame_query: Lucene query applied to frame metadata
-        :param weight: Relative sampling weight for this query
-        :param filter_by_roi: Optional ROI filtering strategy
-        :param label_rules: Optional label-rule dictionaries for ROI filtering
+        :param project_id: Dataset collection identifier or wildcard.
+        :param dataset_id: Dataset identifier or wildcard (legacy), used when version is omitted.
+        :param version_id: Dataset version identifier; defaults to ``dataset_id`` when empty.
+        :param source_query: Lucene query applied to frame source metadata.
+        :param frame_query: Lucene query applied to frame metadata.
+        :param weight: Relative sampling weight for this query.
+        :param filter_by_roi: ROI filtering strategy to apply (see ``FilterByRoiEnum``: ``'disabled'``,
+            ``'no_rois'``, ``'label_rules'``).
+        :param label_rules: Label-rule dictionaries used for ROI filtering.
         """
         Session.verify_feature_set("advanced")
         HyperDatasetQuery._validate_lucene(source_query)
@@ -131,9 +133,9 @@ class HyperDatasetQuery:
         Lucene syntax are not re-validated (no extra server round-trips).
 
         :param rule: `dataviews.FilterRule` (or duck-typed object) fetched from the backend
-        :param dataset_id: Optional concrete dataset id overriding the rule's (used when
+        :param dataset_id: Optional concrete dataset ID overriding the rule's (used when
             expanding a wildcard rule against the dataview's version pool)
-        :param version_id: Optional concrete version id overriding the rule's
+        :param version_id: Optional concrete version ID overriding the rule's
         :return: A `HyperDatasetQuery` instance mirroring the rule
         """
         query = cls.__new__(cls)
@@ -153,7 +155,7 @@ class HyperDatasetQuery:
         """
         Return the dataset identifier targeted by this query.
 
-        :return: Dataset ID string or wildcard marker
+        :return: Dataset ID string or wildcard marker.
         """
         return self._dataset_id
 
@@ -162,7 +164,7 @@ class HyperDatasetQuery:
         """
         Return the dataset collection identifier associated with this query.
 
-        :return: Project ID string or wildcard marker
+        :return: Project ID string or wildcard marker.
         """
         return self._project_id
 
@@ -171,7 +173,7 @@ class HyperDatasetQuery:
         """
         Return the dataset version identifier resolved for this query.
 
-        :return: Version ID string or wildcard marker
+        :return: Version ID string or wildcard marker.
         """
         return self._version_id
 
@@ -180,7 +182,7 @@ class HyperDatasetQuery:
         """
         Return the Lucene query applied to frame source metadata.
 
-        :return: Lucene query string or None
+        :return: Lucene query string, or ``None``.
         """
         return self._source_query
 
@@ -189,7 +191,7 @@ class HyperDatasetQuery:
         """
         Return the Lucene query applied to frame-level metadata.
 
-        :return: Lucene query string or None
+        :return: Lucene query string, or ``None``.
         """
         return self._frame_query
 
@@ -198,7 +200,7 @@ class HyperDatasetQuery:
         """
         Return the relative sampling weight assigned to this query.
 
-        :return: Sampling weight as a float
+        :return: Sampling weight as a float.
         """
         return self._weight
 
@@ -207,7 +209,7 @@ class HyperDatasetQuery:
         """
         Return the ROI filtering strategy configured for this query.
 
-        :return: ROI filter identifier or None
+        :return: ROI filter identifier, or ``None``.
         """
         return self._filter_by_roi
 
@@ -216,7 +218,7 @@ class HyperDatasetQuery:
         """
         Return the label rule definitions used for ROI filtering.
 
-        :return: Sequence of mapping of label rules, or None
+        :return: Sequence of label rule mappings, or ``None``.
         """
         return self._label_rules
 
@@ -260,20 +262,20 @@ class DataView:
         project_name: Optional[str] = None,
     ) -> None:
         """
-        Instantiate a `DataView` wrapper around backend dataview resources.
+        Instantiate a ``DataView`` wrapper around backend dataview resources.
 
         The dataview aggregates query rules and iteration parameters. When running under a ClearML task it
         can optionally auto-connect and restore previously attached definitions.
 
-        :param name: Optional dataview name
-        :param description: Optional descriptive text
-        :param tags: Optional list of tag strings
-        :param iteration_order: Iteration order (`sequential` or `random`)
-        :param iteration_infinite: Whether to iterate indefinitely
-        :param iteration_random_seed: Seed used for random iteration
-        :param iteration_limit: Explicit maximum number of frames to iterate (None means unlimited)
-        :param auto_connect_with_task: Auto-attach to the current ClearML task when True
-        :param project_name: Optional project name under which the DataView will be persisted
+        :param name: Dataview name.
+        :param description: Descriptive text for the dataview.
+        :param tags: List of tag strings.
+        :param iteration_order: Iteration order, ``'sequential'`` or ``'random'``.
+        :param iteration_infinite: If ``True``, iterate indefinitely.
+        :param iteration_random_seed: Seed used for random iteration.
+        :param iteration_limit: Explicit maximum number of frames to iterate (``None`` means unlimited).
+        :param auto_connect_with_task: If ``True``, auto-attach to the current ClearML task.
+        :param project_name: Project name under which the DataView will be persisted
             when stored. If omitted, falls back to the current Task's project. Required on
             servers with project-scoped RBAC for the auto-store to succeed.
         """
@@ -345,7 +347,7 @@ class DataView:
         """
         Return the backend identifier of the materialised DataView.
 
-        :return: DataView ID string or None when not yet created
+        :return: DataView ID string, or ``None`` when not yet created.
         """
         return self._id
 
@@ -354,7 +356,7 @@ class DataView:
         """
         Return the human-readable name assigned to this DataView.
 
-        :return: DataView name string or None
+        :return: DataView name string, or ``None``.
         """
         return self._name
 
@@ -363,7 +365,7 @@ class DataView:
         """
         Update the human-readable name associated with this DataView.
 
-        :param value: New DataView name string or None
+        :param value: New DataView name string, or ``None``.
         """
         self._name = value
 
@@ -383,10 +385,10 @@ class DataView:
         :param dataview_name: The name of the DataView. If more than one DataView shares
             the name, the most recently created one is selected (a warning is logged).
 
-        :return: A new DataView object populated from the stored definition
+        :return: A new DataView object populated from the stored definition.
 
         .. note::
-            ``dataview_id`` and ``dataview_name`` are mutually exclusive.
+            ```dataview_id``` and ```dataview_name``` are mutually exclusive.
             Exactly one of them must be provided, otherwise a ValueError is raised.
         """
         mutually_exclusive(_exception_cls=ValueError, dataview_id=dataview_id, dataview_name=dataview_name)
@@ -487,7 +489,11 @@ class DataView:
         self._synthetic_epoch_limit = None
 
     def get_queries(self) -> List[HyperDatasetQuery]:
-        """Return current HyperDatasetQuery objects attached to this dataview."""
+        """
+        Return the ``HyperDatasetQuery`` objects currently attached to this dataview.
+
+        :return: A list of ``HyperDatasetQuery`` objects.
+        """
         return list(self._queries)
 
     def _mutation_allowed(self) -> bool:
@@ -549,7 +555,8 @@ class DataView:
         """
         Replace all existing queries with the supplied collection.
 
-        :param queries: Iterable of `HyperDatasetQuery` objects; pass None or an empty iterable to clear
+        :param queries: Iterable of ``HyperDatasetQuery`` objects. Pass ``None`` or an empty iterable to
+            clear the queries.
         """
         if not self._mutation_allowed():
             return
@@ -588,17 +595,17 @@ class DataView:
         label_rules: Optional[Any] = None,  # Optional[Sequence[dataviews.FilterLabelRule]]
     ) -> HyperDatasetQuery:
         """
-        Construct and append a single `HyperDatasetQuery` without instantiating it externally.
+        Construct and append a single ``HyperDatasetQuery`` without instantiating it externally.
 
-        :param project_id: Dataset collection identifier or wildcard
-        :param dataset_id: Dataset identifier or wildcard
-        :param version_id: Dataset version identifier
-        :param source_query: Lucene query applied to frame sources
-        :param frame_query: Lucene query applied to frame metadata
-        :param weight: Sampling weight when combining multiple queries
-        :param filter_by_roi: ROI filtering strategy name
-        :param label_rules: Optional label rule definitions for ROI filtering
-        :return: The created `HyperDatasetQuery` instance
+        :param project_id: Dataset collection identifier or wildcard.
+        :param dataset_id: Dataset identifier or wildcard.
+        :param version_id: Dataset version identifier.
+        :param source_query: Lucene query applied to frame sources.
+        :param frame_query: Lucene query applied to frame metadata.
+        :param weight: Sampling weight when combining multiple queries.
+        :param filter_by_roi: ROI filtering strategy name.
+        :param label_rules: Label rule definitions for ROI filtering.
+        :return: The created ``HyperDatasetQuery`` instance.
         """
         query = HyperDatasetQuery(
             project_id=project_id,
@@ -616,7 +623,9 @@ class DataView:
 
     def get_iteration_parameters(self):
         """
-        :return: The cached iteration configuration for this dataview.
+        Return the current iteration configuration for this dataview.
+
+        :return: A dictionary with the ``order``, ``infinite``, ``limit``, and ``random_seed`` keys.
         """
         return {
             "order": self._iteration_order,
@@ -633,6 +642,11 @@ class DataView:
     ):
         """
         Persist iteration settings both locally and on the backend if possible.
+
+        :param infinite: If ``True``, iterate indefinitely; if ``False``, respect ``limit``. If omitted,
+            the current setting is left unchanged.
+        :param limit: Maximum number of frames to iterate. Passing ``None`` explicitly clears the limit
+            (unlimited); omitting this parameter leaves the current limit unchanged.
         """
         if (infinite is not None) or (limit is not _UNSET):
             if infinite is not None:
@@ -657,10 +671,10 @@ class DataView:
         """
         Append one or more query rules to the dataview.
 
-        If the dataview already exists on the backend the remote filter rules are updated immediately and
+        If the dataview already exists on the backend, the remote filter rules are updated immediately and
         the attached task is re-synchronised.
 
-        :param queries: A `HyperDatasetQuery` instance or iterable of instances to add
+        :param queries: A ``HyperDatasetQuery`` instance, or an iterable of instances, to add.
         """
         if not self._mutation_allowed():
             return
@@ -691,7 +705,7 @@ class DataView:
 
         :param label_dict: Mapping from a label string to its integer representation,
             e.g. ``{'cat': 0, 'dog': 1, 'hound': 1}``. Pass an empty dict to clear
-            the enumeration
+            the enumeration.
         """
         if not isinstance(label_dict, dict) or not all(
             isinstance(key, str) and isinstance(value, int) and not isinstance(value, bool)
@@ -718,7 +732,7 @@ class DataView:
         Return the current dataview label enumeration (label string to integer).
 
         :return: Dictionary of label string to integer, e.g. ``{'cat': 0, 'dog': 1}``.
-            Empty when no enumeration was set
+            Empty when no enumeration was set.
         """
         return dict(self._labels_enumeration or {})
 
@@ -753,18 +767,18 @@ class DataView:
             according to the dataset's original labels.
 
         :param from_labels: Label or list of labels to map to ``to_label``. An ROI must
-            match *all* of the labels for the mapping to take place
-        :param to_label: Label to change ``from_labels`` to
+            match *all* of the labels for the mapping to take place.
+        :param to_label: Label to change ``from_labels`` to.
         :param dataset_id: The ID of the dataset to apply the mapping rule to.
-            Defaults to '*' (all datasets in the view). Mutually exclusive with ``dataset_name``
-        :param dataset_name: The name of the dataset to apply the mapping rule to
+            Defaults to ``'*'`` (all datasets in the view). Mutually exclusive with ``dataset_name``.
+        :param dataset_name: The name of the dataset to apply the mapping rule to.
         :param version_id: The ID of the dataset version to apply the mapping rule to.
-            Defaults to '*' (all versions of the dataset in the view). Mutually
-            exclusive with ``version_name``
+            Defaults to ``'*'`` (all versions of the dataset in the view). Mutually
+            exclusive with ``version_name``.
         :param version_name: The name of the dataset version to apply the mapping rule to.
-            Requires ``dataset_id`` or ``dataset_name``
-        :param project_name: Optional project filter used when resolving ``dataset_name``
-        :return: The created `dataviews.MappingRule` object
+            Requires ``dataset_id`` or ``dataset_name``.
+        :param project_name: Project filter used when resolving ``dataset_name``.
+        :return: The created ``dataviews.MappingRule`` object.
         """
         if not to_label or not isinstance(to_label, str):
             raise ValueError("add_mapping_rule expects a non-empty to_label string")
@@ -804,7 +818,7 @@ class DataView:
         """
         Return the current label mapping rules attached to this dataview.
 
-        :return: List of `dataviews.MappingRule` objects
+        :return: List of ``dataviews.MappingRule`` objects.
         """
         return list(self._mapping_rules)
 
@@ -858,7 +872,7 @@ class DataView:
         Build a `frames.Dataview` payload from this DataView's current local state.
 
         Used by read paths (count, iteration) so they hit the inline `frames.*ForDataview`
-        endpoints — no stored DataView id required, no project write permission required.
+        endpoints — no stored DataView ID required, no project write permission required.
         """
         version_pairs = self._collect_version_pairs()
 
@@ -895,18 +909,18 @@ class DataView:
 
     def store(self, project_name: Optional[str] = None) -> str:
         """
-        Persist this DataView on the server and return its id.
+        Persist this DataView on the server and return its ID.
 
         DataViews are stored automatically the first time they are iterated, unless
         ``sdk.development.store_dataviews_on_creation`` is set to false in clearml.conf —
         in which case this method is the explicit way to persist one.
 
-        :param project_name: Optional project name to attach the DataView to. Overrides
+        :param project_name: Project name to attach the DataView to. Overrides
             the value passed at construction. If omitted, the constructor's value
             (or the current Task's project as a fallback) is used.
-        :return: The DataView id assigned by the server.
-        :raises: The underlying SendError when the server rejects the create call (for
-            example, when the user lacks write permission to the resolved project).
+        :return: The DataView ID assigned by the server.
+        :raises SendError: When the server rejects the create call (for example, when the user lacks
+            write permission to the resolved project).
         """
         if project_name is not None:
             self._project_name = project_name
@@ -916,7 +930,7 @@ class DataView:
 
     def _ensure_created(self) -> None:
         """
-        Auto-store hook called from read paths that need an id (e.g. iteration).
+        Auto-store hook called from read paths that need an ID (e.g. iteration).
 
         Honors ``sdk.development.store_dataviews_on_creation``: when disabled, returns
         without contacting the server. Errors during the auto-store are caught and
@@ -1175,17 +1189,19 @@ class DataView:
         """
         Return an iterator configured to stream frames for this dataview.
 
-        :param projection: Optional projection list selecting frame fields
-        :param query_cache_size: Number of frames to request per backend batch
-        :param query_queue_depth: Queue depth used by the background fetcher
-        :param allow_repetition: Enable synthetic epoch length balancing across queries
-        :param auto_synthetic_epoch_limit: Legacy flag equivalent to `allow_repetition`
-        :param node_id: Explicit node identifier to send to the backend
-        :param worker_index: Worker index when splitting frames across multiple iterators
-        :param num_workers: Total number of cooperating workers
-        :param cache_in_memory: Reserved flag (currently unused)
+        :param projection: List of frame fields to include. Include ``'*'`` in the list (or omit this
+            parameter) to include all fields.
+        :param query_cache_size: Number of frames to request per backend batch.
+        :param query_queue_depth: Queue depth used by the background fetcher.
+        :param allow_repetition: If ``True``, enable synthetic epoch length balancing across queries.
+        :param auto_synthetic_epoch_limit: Legacy flag, equivalent to ``allow_repetition``.
+        :param node_id: Explicit node identifier to send to the backend.
+        :param worker_index: Worker index when splitting frames across multiple iterators.
+        :param num_workers: Total number of cooperating workers.
+        :param cache_in_memory: If ``True``, cache fetched items in memory so a subsequent full
+            iteration replays them without re-fetching from the backend.
 
-        :return: Iterator streaming `DataEntry`-derived objects
+        :return: Iterator streaming ``DataEntry``-derived objects.
         """
         if query_cache_size is None:
             query_cache_size = self._MAX_BATCH_SIZE if running_remotely() else self._DEFAULT_LOCAL_BATCH_SIZE
@@ -1251,7 +1267,9 @@ class DataView:
         """
         Fetch total frames count from backend and cache it.
 
-        Sends an inline DataView spec — no stored id required.
+        Sends an inline DataView spec — no stored ID required.
+
+        :return: Total number of frames matching this dataview's queries.
         """
         if self._count_cache is not None:
             return self._count_cache
@@ -1278,12 +1296,14 @@ class DataView:
         """
         Prefetch data entry sources (and optionally previews/masks) into the local cache.
 
-        - num_workers: number of worker threads (defaults to cpu count via ThreadPoolExecutor)
-        - wait: block until all prefetch tasks complete
-        - query_cache_size: data entries per backend fetch batch (defaults to iterator default)
-        - get_previews: also prefetch preview URIs if available
-        - get_masks: also prefetch mask URIs if available
-        - force_download: bypass local cache if True
+        :param num_workers: Number of worker threads (defaults to the CPU count via
+            ``ThreadPoolExecutor``).
+        :param wait: If ``True``, block until all prefetch tasks complete.
+        :param query_cache_size: Number of data entries to fetch per backend batch (defaults to the
+            iterator's default).
+        :param get_previews: If ``True``, also prefetch preview URIs, when available.
+        :param get_masks: If ``True``, also prefetch mask URIs, when available.
+        :param force_download: If ``True``, bypass the local cache and re-download sources.
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -1470,7 +1490,7 @@ class DataView:
             """
             Return the effective iteration limit for this iterator instance.
 
-            :return: Maximum number of frames to yield, or None
+            :return: Maximum number of frames to yield, or ``None``.
             """
             return self._limit
 
@@ -1479,13 +1499,18 @@ class DataView:
             """
             Resolve the backend node identifier used for fetching frames.
 
-            :return: Node identifier integer or None
+            :return: Node identifier integer, or ``None``.
             """
             return self._resolve_node_id()
 
         def set_node(self, node_id=None):
             """
             Force the iterator to use a specific node identifier for backend fetches.
+
+            :param node_id: Node identifier to use, or ``None`` to clear it and fall back to
+                auto-detection.
+            :raises ValueError: If called after the iterator has already started, or if ``node_id``
+                cannot be converted to an int.
             """
             if self._started and getattr(self, "_fetch_thread", None) and self._fetch_thread.is_alive():
                 raise ValueError("Cannot change node id after iterator has started")
@@ -1500,6 +1525,13 @@ class DataView:
         def set_concurrency(self, worker_index=None, num_workers=None):
             """
             Configure worker splitting so multiple iterators can share the same dataview.
+
+            :param worker_index: This worker's index among ``num_workers`` cooperating workers. If
+                omitted, falls back to the iterator's node identifier (or an auto-detected one).
+            :param num_workers: Total number of cooperating workers. If omitted, the worker count is
+                auto-detected; when only one worker is detected, concurrency splitting is disabled.
+            :raises ValueError: If called after the iterator has already started, if ``num_workers`` or
+                ``worker_index`` cannot be converted to an int, or if ``worker_index`` is negative.
             """
             if self._started and getattr(self, "_fetch_thread", None) and self._fetch_thread.is_alive():
                 raise ValueError("set_concurrency must be called before the iterator starts")

--- a/clearml/hyperdatasets/management.py
+++ b/clearml/hyperdatasets/management.py
@@ -29,15 +29,15 @@ class HyperDatasetManagement:
         version_id: Optional[str] = None,
     ) -> HD:
         """
-        Return a `HyperDataset` handle bound to an existing dataset/version.
+        Return a ``HyperDataset`` handle bound to an existing dataset/version.
 
-        :param dataset_name: Dataset collection name. Mutually exclusive with `dataset_id`
-        :param version_name: Version name. Mutually exclusive with `version_id`
-        :param project_name: Optional ClearML project filter when using `dataset_name`
-        :param dataset_id: Dataset identifier. Mutually exclusive with `dataset_name`
-        :param version_id: Version identifier. Mutually exclusive with `version_name`
+        :param dataset_name: Dataset collection name. Mutually exclusive with ``dataset_id``.
+        :param version_name: Version name. Mutually exclusive with ``version_id``.
+        :param project_name: ClearML project filter used when resolving by ``dataset_name``.
+        :param dataset_id: Dataset identifier. Mutually exclusive with ``dataset_name``.
+        :param version_id: Version identifier. Mutually exclusive with ``version_name``.
 
-        :return: `HyperDataset` instance pointing at the requested dataset/version
+        :return: A ``HyperDataset`` instance pointing at the requested dataset/version.
         """
 
         if dataset_name and dataset_id:
@@ -99,13 +99,13 @@ class HyperDatasetManagement:
         """
         Check whether a dataset (and optionally a specific version) exists.
 
-        :param dataset_name: Dataset collection name. Mutually exclusive with `dataset_id`
-        :param version_name: Dataset version name. Mutually exclusive with `version_id`
-        :param project_name: Optional project filter when searching by name
-        :param dataset_id: Dataset identifier to query. Mutually exclusive with `dataset_name`
-        :param version_id: Version identifier to query. Mutually exclusive with `version_name`
+        :param dataset_name: Dataset collection name. Mutually exclusive with ``dataset_id``.
+        :param version_name: Dataset version name. Mutually exclusive with ``version_id``.
+        :param project_name: Project filter used when resolving by ``dataset_name``.
+        :param dataset_id: Dataset identifier to query. Mutually exclusive with ``dataset_name``.
+        :param version_id: Version identifier to query. Mutually exclusive with ``version_name``.
 
-        :return: True when the dataset (and requested version) can be found
+        :return: ``True`` if the dataset (and requested version) can be found.
         """
         if dataset_name and dataset_id:
             raise ValueError("Provide either dataset_name or dataset_id, not both")
@@ -157,15 +157,15 @@ class HyperDatasetManagement:
         - ``dataset_id``/``dataset_name`` are mutually exclusive, as are
           ``version_id``/``version_name``
         - ``version_name`` requires a dataset selector (names are only unique per dataset)
-        - names are resolved through ``get()``; explicit ids are verified with ``exists()``
+        - names are resolved through ``get()``; explicit IDs are verified with ``exists()``
         - no selectors at all is valid and resolves to ``('*', '*')``
 
         :param dataset_id: Dataset identifier, or '*' / None for any dataset
-        :param dataset_name: Dataset name to resolve into an id
+        :param dataset_name: Dataset name to resolve into an ID
         :param version_id: Version identifier, or '*' / None for any version
-        :param version_name: Version name to resolve into an id
+        :param version_name: Version name to resolve into an ID
         :param project_name: Optional project filter used when resolving ``dataset_name``
-        :return: Tuple of (dataset id or '*', version id or '*')
+        :return: Tuple of (dataset ID or '*', version ID or '*')
         :raises ValueError: On conflicting selectors or when the referenced
             dataset/version does not exist
         """
@@ -214,13 +214,16 @@ class HyperDatasetManagement:
         """
         List HyperDataset collections matching the provided filters.
 
-        :param project_name: Optional project filter (matches project hierarchy when recursive)
-        :param partial_name: Optional regex / partial dataset name filter
-        :param tags: Optional list of tags to filter by
-        :param ids: Optional list of dataset identifiers
-        :param recursive_project_search: Include subprojects when filtering by project_name
-        :param include_archived: Include archived datasets when True
-        :return: List of dictionaries describing the matching datasets
+        :param project_name: Project filter (matches the project hierarchy when
+            ``recursive_project_search`` is ``True``).
+        :param partial_name: Regex / partial dataset name filter.
+        :param tags: List of tags to filter by.
+        :param ids: List of dataset identifiers to filter by.
+        :param recursive_project_search: If ``True``, include subprojects when filtering by
+            ``project_name`` (default ``True``).
+        :param include_archived: If ``True``, include archived datasets (default ``True``).
+
+        :return: A list of dictionaries, each describing a matching dataset.
         """
         return HyperDatasetManagementBackend.list(
             dataset_project=project_name,
@@ -243,12 +246,12 @@ class HyperDatasetManagement:
         """
         Delete a dataset or a specific dataset version.
 
-        :param dataset_name: Dataset name to delete (required)
-        :param version_name: Version name to delete. When omitted, the entire dataset is removed
-        :param project_name: Optional project context when resolving by name
-        :param force: Force deletion even when there are protections
+        :param dataset_name: Dataset name to delete (required).
+        :param version_name: Version name to delete. When omitted, the entire dataset is removed.
+        :param project_name: Project filter used when resolving by ``dataset_name``.
+        :param force: If ``True``, force deletion even when there are protections (default ``False``).
 
-        :return: True when deletion completes successfully
+        :return: ``True`` if deletion completes successfully.
         """
         session = Session()
         project_id = get_existing_project(session, project_name) if project_name else None
@@ -285,12 +288,14 @@ class HyperDatasetManagement:
         """
         Commit the bound HyperDataset version to refresh backend statistics.
 
-        :param publish: Publish the version after committing (optional)
-        :param force: Force publish even when annotation tasks reference the version
-        :param calculate_stats: Control statistics calculation during commit
-        :param override_stats: Optional statistics payload to persist as-is
-        :param publishing_task: Annotation task identifier issuing the commit
-        :return: Backend response payload
+        :param publish: If ``True``, publish the version after committing (default ``False``).
+        :param force: If ``True``, force publish even when annotation tasks reference the version
+            (default ``False``).
+        :param calculate_stats: Whether to calculate statistics during the commit (default ``True``).
+        :param override_stats: Statistics payload to persist instead of recalculating them.
+        :param publishing_task: Annotation task identifier issuing the commit.
+
+        :return: The backend's response payload.
         """
         if not getattr(self, "_version_id", None):
             raise ValueError("HyperDataset instance is not bound to a dataset version")
@@ -313,10 +318,10 @@ class HyperDatasetManagement:
         """
         Publish the bound HyperDataset version.
 
-        :param force: Force publish even with active annotation tasks
-        :param publishing_task: Annotation task identifier issuing the commit
+        :param force: If ``True``, force publish even with active annotation tasks (default ``False``).
+        :param publishing_task: Annotation task identifier issuing the commit.
 
-        :return: Backend response payload
+        :return: The backend's response payload.
         """
         if not getattr(self, "_version_id", None):
             raise ValueError("HyperDataset instance is not bound to a dataset version")

--- a/clearml/hyperdatasets/util.py
+++ b/clearml/hyperdatasets/util.py
@@ -37,12 +37,12 @@ def set_dataview(task: "Task", dataview) -> None:
     (i.e. under `input.*`), so the DataView appears in the UI, without using
     runtime properties.
 
-    - If `dataview` is a string id, the backend is queried to fetch its full
+    - If `dataview` is a string ID, the backend is queried to fetch its full
       definition and it is serialized into the task's `input` section.
     - If `dataview` is a `DataView`, its current state is serialized
       into the task's `input` section.
 
-    :param dataview: DataView instance or dataview id string
+    :param dataview: DataView instance or dataview ID string
     """
     # Avoid top-level import to prevent cycles
     try:
@@ -242,7 +242,7 @@ def set_dataview(task: "Task", dataview) -> None:
                 "artifacts": getattr(getattr(task.data, "execution", {}), "artifacts", []) or [],
             }
         except Exception as e:
-            get_logger("task").exception(f"Failed fetching dataview by id {dv_id}: {e}")
+            get_logger("task").exception(f"Failed fetching dataview by ID {dv_id}: {e}")
             return
     # Case 2: SDK DataView object
     elif DataView and isinstance(dataview, DataView):

--- a/clearml/router/router.py
+++ b/clearml/router/router.py
@@ -7,9 +7,8 @@ from .proxy import HttpProxy
 
 class HttpRouter:
     """
-    A router class to manage HTTP routing for an application.
-    Allows the creation, deployment, and management of local and external endpoints,
-    as well as the configuration of a local proxy for traffic routing.
+    An HttpRouter manages HTTP routing for an application: it creates, deploys, and manages local and
+    external endpoints, and configures a local proxy for traffic routing.
 
     Example usage:
 
@@ -43,7 +42,7 @@ class HttpRouter:
 
     def __init__(self, task: Any) -> None:
         """
-        Do not use directly. Use `Task.get_router` instead
+        Do not use directly. Use ``Task.get_http_router()`` instead.
         """
         self._task = task
         self._external_endpoint_port = None
@@ -59,16 +58,16 @@ class HttpRouter:
         enable_streaming: bool = True,
     ) -> None:
         """
-        Set the parameters with which the local proxy is initialized
+        Set the parameters with which the local proxy is initialized.
 
-        :param incoming_port: The incoming port of the proxy
-        :param default_target: If None, no default target is set. Otherwise, route all traffic
-            that doesn't match a local route created via `create_local_route` to this target
+        :param incoming_port: The incoming port of the proxy.
+        :param default_target: If ``None``, no default target is set. Otherwise, route all traffic
+            that doesn't match a local route created via ``create_local_route()`` to this target.
         :param log_level: Python log level for the proxy, one of:
-            'critical', 'error', 'warning', 'info', 'debug', 'trace'
-        :param access_log: Enable/Disable access log
-        :param enable_streaming: If True, enable streaming of responses with the `transfer-encoding` header set.
-            If False, no response will be streamed
+            'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+        :param access_log: If ``True``, enable the access log. If ``False``, disable it.
+        :param enable_streaming: If ``True``, enable streaming of responses with the ``transfer-encoding``
+            header set. If ``False``, no response will be streamed.
         """
         self._proxy_params["port"] = incoming_port or HttpProxy.DEFAULT_PORT
         self._proxy_params["default_target"] = default_target
@@ -78,7 +77,7 @@ class HttpRouter:
 
     def start_local_proxy(self) -> None:
         """
-        Start the local proxy without deploying the router, i.e. requesting an external endpoint
+        Start the local proxy without deploying the router, i.e. requesting an external endpoint.
         """
         self._proxy = self._proxy or HttpProxy(**self._proxy_params)
 
@@ -97,55 +96,56 @@ class HttpRouter:
         This function enables routing traffic between the source and target endpoints, optionally
         allowing custom callbacks to handle requests and responses or to gather telemetry data
         at the endpoint.
-        To customize proxy parameters, use the `Router.set_local_proxy_parameters` method.
+        To customize proxy parameters, use the ``HttpRouter.set_local_proxy_parameters()`` method.
         By default, the proxy binds to port 9000 for incoming requests.
 
-        :param source: The source path for routing the traffic. For example, `/` will intercept
-            all the traffic sent to the proxy, while `/example` will only intercept the calls
-            that have `/example` as the path prefix.
+        :param source: The source path for routing the traffic. For example, ``/`` will intercept
+            all the traffic sent to the proxy, while ``/example`` will only intercept the calls
+            that have ``/example`` as the path prefix.
         :param target: The target URL where the intercepted traffic is routed.
         :param request_callback: A function used to process each request before it is forwarded to the target.
             The callback must have the following parameters:
 
-            - request - The intercepted FastAPI request
-            - persistent_state - A dictionary meant to be used as a caching utility object.
+            - ``request`` - The intercepted FastAPI request.
+            - ``persistent_state`` - A dictionary meant to be used as a caching utility object.
 
-            Shared with `response_callback` and `error_callback`.
-            The callback can return a FastAPI Request, in which case this request will be forwarded to the target
+            Shared with ``response_callback`` and ``error_callback``.
+            The callback can return a FastAPI Request, in which case this request will be forwarded to the target.
         :param response_callback: A function used to process each response before it is returned by the proxy.
             The callback must have the following parameters:
 
-            - response - The FastAPI response
-            - request - The FastAPI request (after being preprocessed by the proxy)
-            - persistent_state - A dictionary meant to be used as a caching utility object.
-            Shared with `request_callback` and `error_callback`
-            The callback can return a FastAPI Response, in which case this response will be forwarded
-        :param endpoint_telemetry: If True, enable endpoint telemetry. If False, disable it.
+            - ``response`` - The FastAPI response.
+            - ``request`` - The FastAPI request (after being preprocessed by the proxy).
+            - ``persistent_state`` - A dictionary meant to be used as a caching utility object.
+            Shared with ``request_callback`` and ``error_callback``.
+            The callback can return a FastAPI Response, in which case this response will be forwarded.
+        :param endpoint_telemetry: If ``True``, enable endpoint telemetry. If ``False``, disable it.
             If a dictionary is passed, enable endpoint telemetry with custom parameters.
             The parameters are:
 
-            - endpoint_url - URL to the endpoint, mandatory if no external URL has been requested
-            - endpoint_name - name of the endpoint
-            - model_name - name of the model served by the endpoint
-            - model - referenced model
-            - model_url - URL to the model
-            - model_source - Source of the model
-            - model_version - Model version
-            - app_id - App ID, if used inside a ClearML app
-            - app_instance - The ID of the instance the ClearML app is running
-            - tags - ClearML tags
-            - system_tags - ClearML system tags
-            - container_id - Container ID, should be unique
-            - input_size - input size of the model
-            - input_type - input type expected by the model/endpoint
-            - report_statistics - whether to report statistics
+            - ``endpoint_url`` - URL to the endpoint, mandatory if no external URL has been requested.
+            - ``endpoint_name`` - Name of the endpoint.
+            - ``model_name`` - Name of the model served by the endpoint.
+            - ``model`` - Referenced model.
+            - ``model_url`` - URL to the model.
+            - ``model_source`` - Source of the model.
+            - ``model_version`` - The model's version.
+            - ``app_id`` - App ID, if used inside a ClearML app.
+            - ``app_instance`` - The ID of the instance the ClearML app is running.
+            - ``tags`` - ClearML tags.
+            - ``system_tags`` - ClearML system tags.
+            - ``container_id`` - Container ID, should be unique.
+            - ``input_size`` - The input size expected by the model.
+            - ``input_type`` - The input type expected by the model/endpoint.
+            - ``report_statistics`` - Whether to report endpoint statistics.
         :param error_callback: Callback to be called on request error.
             The callback must have the following parameters:
 
-            - request - the FastAPI request which caused the error
-            - error - an exception which indicates which error occurred
-            - persistent_state - A dictionary meant to be used as a caching utility object.
-            Shared with `request_callback` and `response_callback`
+            - ``request`` - The FastAPI request which caused the error.
+            - ``error`` - An exception which indicates which error occurred.
+            - ``persistent_state`` - A dictionary meant to be used as a caching utility object.
+
+            Shared with ``request_callback`` and ``response_callback``.
         """
         self.start_local_proxy()
         self._proxy.add_route(
@@ -159,9 +159,9 @@ class HttpRouter:
 
     def remove_local_route(self, source: str) -> None:
         """
-        Remove a local route. If endpoint telemetry is enabled for that route, disable it
+        Remove a local route. If endpoint telemetry is enabled for that route, disable it.
 
-        :param source: Remove route based on the source path used to route the traffic
+        :param source: The source path used to route the traffic; the route matching this path is removed.
         """
         if self._proxy:
             self._proxy.remove_route(source)
@@ -174,23 +174,24 @@ class HttpRouter:
         static_route: Optional[str] = None
     ) -> Optional[Dict]:
         """
-        Start the local HTTP proxy and request an external endpoint for an application
+        Start the local HTTP proxy and request an external endpoint for an application.
 
-        :param port: Port the application is listening to. If no port is supplied, a local proxy
-            will be created. To control the proxy parameters, use `Router.set_local_proxy_parameters`.
-            To control create local routes through the proxy, use `Router.create_local_route`.
-            By default, the incoming port bound by the proxy is 9000
-        :param protocol: As of now, only `http` is supported
-        :param wait: If True, wait for the endpoint to be assigned
-        :param wait_interval_seconds: The poll frequency when waiting for the endpoint
+        By default, the incoming port bound by the proxy is 9000. To customize the proxy parameters, use
+        ``HttpRouter.set_local_proxy_parameters()``. To create local routes through the proxy, use
+        ``HttpRouter.create_local_route()``.
+
+        :param wait: If ``True``, wait for the endpoint to be assigned (default ``False``).
+        :param wait_interval_seconds: The poll frequency when waiting for the endpoint.
         :param wait_timeout_seconds: If this timeout is exceeded while waiting for the endpoint,
-            the method will no longer wait and None will be returned
+            the method will no longer wait and ``None`` will be returned.
         :param static_route: The static route name (not the route path).
             When set, the external endpoint requested will use this route
             instead of generating it based on the task ID. Useful for creating
             persistent, load balanced routes.
 
-        :return: If wait is False, this method will return None. If no endpoint could be found while waiting, this method returns None. Otherwise, it returns a dictionary containing the following values:
+        :return: If ``wait`` is ``False``, this method returns ``None``. If ``wait`` is ``True`` but no endpoint
+            could be found before timing out, this method also returns ``None``. Otherwise, it returns a
+            dictionary containing the following values:
 
             - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint
             - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser
@@ -213,13 +214,14 @@ class HttpRouter:
         wait_timeout_seconds: float = 90.0,
     ) -> Optional[Dict]:
         """
-        Wait for an external endpoint to be assigned
+        Wait for an external endpoint to be assigned.
 
-        :param wait_interval_seconds: The poll frequency when waiting for the endpoint
+        :param wait_interval_seconds: The poll frequency when waiting for the endpoint.
         :param wait_timeout_seconds: If this timeout is exceeded while waiting for the endpoint,
-            the method will no longer wait
+            the method will no longer wait.
 
-        :return: If no endpoint could be found while waiting, this method returns None. Otherwise, it returns a dictionary containing the following values:
+        :return: If no endpoint could be found while waiting, this method returns ``None``. Otherwise, it
+            returns a dictionary containing the following values:
 
             - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint
             - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser
@@ -234,7 +236,7 @@ class HttpRouter:
 
     def list_external_endpoints(self) -> List[Dict]:
         """
-        List all external endpoints assigned
+        List all external endpoints assigned.
 
         :return: A list of dictionaries. Each dictionary contains the following values:
 

--- a/clearml/task.py
+++ b/clearml/task.py
@@ -196,7 +196,7 @@ class Task(_Task):
         the ClearML.
 
         The exception to this Task behavior is sub-tasks (non-reproducible Tasks), which do not use the main execution
-        Task. Creating a sub-task always creates a new Task with a new  Task ID.
+        Task. Creating a sub-task always creates a new Task with a new Task ID.
     """
 
     TaskTypes = _Task.TaskTypes
@@ -268,7 +268,6 @@ class Task(_Task):
         object.
 
         :return: The current running Task (experiment).
-        :rtype: Task
         """
         # check if we have no main Task, but the main process created one.
         if not cls.__main_task and cls.__get_master_id_task_id():
@@ -342,10 +341,10 @@ class Task(_Task):
             An ideal location to call it is right after the ```if __name__ == "__main__":``` line
             (assuming all your code execution is in this ```if``` statement block).
 
-        :param str project_name: The name of the project in which the experiment will be created. If the project does
-            not exist, it is created. If ``project_name`` is ``None``, the repository name is used. (Optional)
-        :param str task_name: The name of Task (experiment). If ``task_name`` is ``None``, the Python experiment
-            script's file name is used. (Optional)
+        :param project_name: The name of the project in which the experiment will be created. If the project does
+            not exist, it is created. If ``project_name`` is ``None``, the repository name is used.
+        :param task_name: The name of Task (experiment). If ``task_name`` is ``None``, the Python experiment
+            script's file name is used.
         :param TaskTypes task_type: The task type. Valid task types:
 
             - ``TaskTypes.training`` (default)
@@ -360,17 +359,17 @@ class Task(_Task):
             - ``TaskTypes.qc``
             - ``TaskTypes.custom``
 
-        :param tags: Add a list of tags (``str``) to the created Task. For example: ``tags=['512x512', 'yolov3']``
-        :param bool reuse_last_task_id: Force a new Task (experiment) with a previously used Task ID, and the same project and Task name.
+        :param tags: Add a list of tags (``str``) to the created Task. For example: ``tags=['512x512', 'yolov3']``.
+        :param reuse_last_task_id: Force a new Task (experiment) with a previously used Task ID, and the same project and Task name.
             If the previously executed Task has artifacts or models, it will not be
             reused (overwritten), and a new Task will be created. When a Task is reused, the previous execution outputs
             are deleted, including console outputs and logs. The values are:
 
-          - ``True`` - Reuse the last  Task ID. (default)
+          - ``True`` - Reuse the last Task ID. (default)
           - ``False`` - Force a new Task (experiment).
           - A string - You can also specify a Task ID to be reused, instead of the cached ID based on the project/name combination.
 
-        :param bool continue_last_task: Continue the execution of a previously executed Task (experiment).
+        :param continue_last_task: Continue the execution of a previously executed Task (experiment).
             When continuing the executing of a previously executed Task,
             all previous artifacts / models / logs remain intact.
             New logs will continue iteration/step based on the previous execution maximum iteration value.
@@ -378,11 +377,11 @@ class Task(_Task):
             The values are:
 
           - ``True`` - Continue the last Task ID. Specified explicitly by reuse_last_task_id or implicitly with the same logic as reuse_last_task_id
-          - ``False`` - Overwrite the execution of previous Task  (default).
+          - ``False`` - Overwrite the execution of previous Task (default).
           - A string - You can also specify a Task ID to be continued. This is equivalent to ``continue_last_task=True`` and ``reuse_last_task_id=a_task_id_string``.
           - An integer - Specify initial iteration offset (override the auto automatic ``last_iteration_offset``). Pass 0, to disable the automatic ``last_iteration_offset`` or specify a different initial offset. You can specify a Task ID to be used with ``reuse_last_task_id='task_id_here'``
 
-        :param str output_uri: The default location for output models and other artifacts.
+        :param output_uri: The default location for output models and other artifacts.
             If ``True``, the default ``files_server`` will be used for model storage. In the default location, ClearML creates a subfolder for the
             output. If set to ``False``, local runs will not upload output models and artifacts,
             and remote runs will not use any default values provided using ``default_output_uri``.
@@ -465,7 +464,7 @@ class Task(_Task):
 
                 auto_connect_frameworks={'tensorboard': {'report_hparams': False}}
 
-        :param bool auto_resource_monitoring: Automatically create machine resource monitoring plots.
+        :param auto_resource_monitoring: Automatically create machine resource monitoring plots.
             These plots appear in the **ClearML Web-App (UI)**, **RESULTS** tab, **SCALARS** sub-tab,
             with a title of **:resource monitor:**.
 
@@ -518,8 +517,7 @@ class Task(_Task):
           - Before ``Task.init`` completes in the background, auto-magic logging (console/metric) might be missed
           - If running via an agent, this argument is ignored, and Task init is called synchronously (default)
 
-        :return: The main execution Task (Task context)
-        :rtype: Task
+        :return: The main execution Task (Task context).
         """
 
         def verify_defaults_match() -> None:
@@ -993,28 +991,28 @@ class Task(_Task):
         endpoint_name: Optional[str] = None,
     ) -> Optional[Dict]:
         """
-        Request an external endpoint for an application
+        Request an external endpoint for an application.
 
-        :param port: Port the application is listening to
-        :param protocol: ``http`` or ``tcp``
-        :param wait: If ``True``, wait for the endpoint to be assigned
-        :param wait_interval_seconds: The poll frequency when waiting for the endpoint
+        :param port: Port the application is listening to.
+        :param protocol: ``http`` or ``tcp``.
+        :param wait: If ``True``, wait for the endpoint to be assigned.
+        :param wait_interval_seconds: The poll frequency when waiting for the endpoint.
         :param wait_timeout_seconds: If this timeout is exceeded while waiting for the endpoint,
-            the method will no longer wait and ``None`` will be returned
+            the method will no longer wait and ``None`` will be returned.
         :param static_route: The static route name (not the route path).
             When set, the external endpoint requested will use this route
             instead of generating it based on the task ID. Useful for creating
             persistent, load balanced routes.
-        :param endpoint_name: Optional identifier for this endpoint. Useful to distinguish
-            between multiple endpoints. If not provided, the endpoint_name is auto-generated
+        :param endpoint_name: Identifier for this endpoint. Useful to distinguish
+            between multiple endpoints. If not provided, the endpoint_name is auto-generated.
 
         :return: If wait is ``False``, this method will return ``None``. If no endpoint could be found while waiting, this method returns ``None``. Otherwise, it returns a dictionary containing the following values:
 
-          - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint
-          - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser
-          - ``port`` - the port exposed by the application
-          - ``protocol`` - the protocol used by the endpoint
-          - ``name`` - the identifier used for this endpoint
+          - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint.
+          - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser.
+          - ``port`` - the port exposed by the application.
+          - ``protocol`` - the protocol used by the endpoint.
+          - ``name`` - the identifier used for this endpoint.
         """
         Session.verify_feature_set("advanced")
         if protocol not in self._external_endpoint_port_map.keys():
@@ -1112,24 +1110,25 @@ class Task(_Task):
         endpoint_name: Optional[str] = None,
     ) -> Union[Optional[Dict], List[Optional[Dict]]]:
         """
-        Wait for an external endpoint to be assigned
+        Wait for an external endpoint to be assigned.
 
-        :param wait_interval_seconds: The poll frequency when waiting for the endpoint
+        :param wait_interval_seconds: The poll frequency when waiting for the endpoint.
         :param wait_timeout_seconds: If this timeout is exceeded while waiting for the endpoint,
-            the method will no longer wait
+            the method will no longer wait.
         :param protocol: ``http`` or ``tcp``. Wait for an endpoint to be assigned based on the protocol.
-            If ``None``, wait for all supported protocols
-        :param endpoint_name: Optional identifier of the endpoint to wait on.
+            If ``None``, wait for all supported protocols.
+        :param endpoint_name: Identifier of the endpoint to wait on.
 
         :return: If no endpoint could be found while waiting, this method returns ``None``. If a protocol has been specified, it returns a dictionary containing the following values:
 
-          - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint
-          - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser
-          - ``port`` - the port exposed by the application
-          - ``protocol`` - the protocol used by the endpoint
+          - ``endpoint`` - raw endpoint. One might need to authenticate in order to use this endpoint.
+          - ``browser_endpoint`` - endpoint to be used in browser. Authentication will be handled via the browser.
+          - ``port`` - the port exposed by the application.
+          - ``protocol`` - the protocol used by the endpoint.
           - ``name`` - the identifier used for this endpoint.
-            If protocol is not specified, it returns a list of dictionaries containing the values above,
-            for each protocol requested and waited
+
+          If protocol is not specified, it returns a list of dictionaries containing the values above,
+          for each protocol requested and waited.
         """
         Session.verify_feature_set("advanced")
         if protocol is None and endpoint_name is not None:
@@ -1237,18 +1236,18 @@ class Task(_Task):
 
     def list_external_endpoints(self, protocol: Optional[str] = None) -> List[Dict]:
         """
-        List all external endpoints assigned
+        List all external endpoints assigned.
 
         :param protocol: If ``None``, list all external endpoints. Otherwise, only list endpoints
-            that use this protocol
+            that use this protocol.
 
         :return: A list of dictionaries. Each dictionary contains the following values:
 
-          - ``endpoint`` - Raw endpoint. One might need to authenticate in order to use this endpoint
-          - ``browser_endpoint`` - Endpoint to be used in browser. Authentication will be handled via the browser
-          - ``port`` - The port exposed by the application
-          - ``protocol`` - The protocol used by the endpoint
-          - ``name`` - The identifier used for this endpoint
+          - ``endpoint`` - Raw endpoint. One might need to authenticate in order to use this endpoint.
+          - ``browser_endpoint`` - Endpoint to be used in browser. Authentication will be handled via the browser.
+          - ``port`` - The port exposed by the application.
+          - ``protocol`` - The protocol used by the endpoint.
+          - ``name`` - The identifier used for this endpoint.
         """
         Session.verify_feature_set("advanced")
         runtime_props = self._get_runtime_properties()
@@ -1328,45 +1327,44 @@ class Task(_Task):
 
         :param project_name: Set the project name for the task. Required if base_task_id is ``None``.
         :param task_name: Set the name of the remote task. Required if base_task_id is ``None``.
-        :param task_type: Optional, The task type to be created. Supported values: 'training', 'testing', 'inference',
-            'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc', 'custom'
+        :param task_type: The task type to be created. Supported values: 'training', 'testing', 'inference',
+            'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc', 'custom'.
         :param repo: Remote URL for the repository to use, or path to local copy of the git repository.
-            Example: 'https://github.com/allegroai/clearml.git' or '~/project/repo'. If ``repo`` is specified, then
-            the ``script`` parameter must also be specified
-        :param branch: Select specific repository branch/tag (implies the latest commit from the branch)
+            Example: 'https://github.com/clearml/clearml.git' or '~/project/repo'. If ``repo`` is specified, then
+            the ``script`` parameter must also be specified.
+        :param branch: Select specific repository branch/tag (implies the latest commit from the branch).
         :param commit: Select specific commit ID to use (default: latest commit,
-            or when used with local repository matching the local commit ID)
+            or when used with local repository matching the local commit ID).
         :param script: Specify the entry point script for the remote execution. When used in tandem with
             remote git repository the script should be a relative path inside the repository,
             for example: './source/train.py' . When used with local repository path it supports a
-            direct path to a file inside the local repository itself, for example: '~/project/source/train.py'
+            direct path to a file inside the local repository itself, for example: '~/project/source/train.py'.
         :param working_directory: Working directory to launch the script from. Default: repository root folder.
             Relative to repo root or local folder.
         :param packages: Manually specify a list of required packages. Example: ``["tqdm>=2.1", "scikit-learn"]``
             or ``True`` to automatically create requirements
             based on locally installed packages (repository must be local).
-            Pass an empty string to not install any packages (not even from the repository)
+            Pass an empty string to not install any packages (not even from the repository).
         :param requirements_file: Specify requirements.txt file to install when setting the session.
             If not provided, the requirements.txt from the repository will be used.
-        :param docker: Select the docker image to be executed in by the remote session
-        :param docker_args: Add docker arguments, pass a single string
+        :param docker: Select the docker image to be executed in by the remote session.
+        :param docker_args: Add docker arguments, pass a single string.
         :param docker_bash_setup_script: Add bash script to be executed
-            inside the docker before setting up the Task's environment
-        :param argparse_args: Arguments to pass to the remote execution, list of string pairs (argument, value)
-            Notice, only supported if the codebase itself uses ``argparse.ArgumentParser``
+            inside the docker before setting up the Task's environment.
+        :param argparse_args: Arguments to pass to the remote execution, list of string pairs (argument, value).
+            Notice, only supported if the codebase itself uses ``argparse.ArgumentParser``.
         :param base_task_id: Use a pre-existing task in the system, instead of a local repo/script.
             Essentially clones an existing task and overrides arguments/requirements.
         :param add_task_init_call: If ``True``, a ``Task.init()`` call is added to the script entry point in remote execution.
-        :param force_single_script_file: If ``True``, do not auto-detect local repository
-        :param binary: Binary used to launch the entry point
+        :param force_single_script_file: If ``True``, do not auto-detect local repository.
+        :param binary: Binary used to launch the entry point.
         :param module: If specified instead of executing ``script``, a module named ``module`` is executed.
             Implies script is empty. Module can contain multiple argument for execution,
-            for example: ``module="my.module arg1 arg2"``
+            for example: ``module="my.module arg1 arg2"``.
         :param detect_repository: If ``True``, detect the repository if no repository has been specified.
-            If ``False``, don't detect repository under any circumstance. Ignored if ``repo`` is specified
+            If ``False``, don't detect repository under any circumstance. Ignored if ``repo`` is specified.
 
-        :return: The newly created Task (experiment)
-        :rtype: Task
+        :return: The newly created Task (experiment).
         """
         if cls.is_offline():
             raise UsageError("Creating task in offline mode. Use 'Task.init' instead.")
@@ -1411,13 +1409,12 @@ class Task(_Task):
     @classmethod
     def get_by_name(cls, task_name: str) -> TaskInstance:
         """
+        Returns the most recent task with the given name from anywhere in the system as a Task object.
 
         .. note::
             This method is deprecated, use ```Task.get_task``` instead.
 
-        Returns the most recent task with the given name from anywhere in the system as a Task object.
-
-        :param str task_name: The name of the task to search for.
+        :param task_name: The name of the task to search for.
 
         :return: Task object of the most recent task with that name.
         """
@@ -1470,10 +1467,10 @@ class Task(_Task):
             for x in range(10):
                 train_task.get_logger().report_scalar('title', 'series', value=x * 2, iteration=x)
 
-        :param str task_id: The ID (system UUID) of the experiment to get.
+        :param task_id: The ID (system UUID) of the experiment to get.
             If specified, ``project_name`` and ``task_name`` are ignored.
-        :param str project_name: The project name of the Task to get.
-        :param str task_name: The name of the Task within ``project_name`` to get.
+        :param project_name: The project name of the Task to get.
+        :param task_name: The name of the Task within ``project_name`` to get.
         :param list tags: Filter based on the requested list of tags (``str``). To exclude a tag add "-" prefix to the
             tag. Example: ``["best", "-debug"]``.
             The default behaviour is to join all tags with a logical "OR" operator.
@@ -1499,13 +1496,12 @@ class Task(_Task):
 
             This example means ("a" AND "b" AND "c" AND ("d" OR NOT "e") AND ("f" OR "g")).
             See https://clear.ml/docs/latest/docs/clearml_sdk/task_sdk/#tag-filters for more information.
-        :param bool allow_archived: Only applicable if *not* using specific ``task_id``,
-            If ``True`` (default), allow to return archived Tasks. If ``False`` filter out archived Tasks
-        :param bool task_filter: Only applicable if *not* using specific ``task_id``,
+        :param allow_archived: Only applicable if *not* using specific ``task_id``.
+            If ``True`` (default), allow to return archived Tasks. If ``False`` filter out archived Tasks.
+        :param task_filter: Only applicable if *not* using specific ``task_id``.
             Pass additional query filters, on top of project/name. See details in ``Task.get_tasks``.
 
         :return: The Task specified by ID, or project name / experiment name combination.
-        :rtype: Task
         """
         return cls.__get_task(
             task_id=task_id,
@@ -1530,23 +1526,22 @@ class Task(_Task):
         Get a list of Tasks objects matching the queries/filters:
 
         - A list of specific Task IDs.
-        - Filter Tasks based on specific fields:
-            project name (including partial match), task name (including partial match), tags
-            Apply Additional advanced filtering with ``task_filter``
+        - Filter Tasks based on specific fields: project name (including partial match), task name (including
+          partial match), tags. Apply additional advanced filtering with ``task_filter``.
 
         .. note::
             This function returns the most recent 500 tasks. If you wish to retrieve older tasks
             use ```Task.query_tasks()```
 
-        :param list(str) task_ids: The IDs (system UUID) of experiments to get.
+        :param list task_ids: The IDs (system UUID) of experiments to get.
             If ``task_ids`` specified, then ``project_name`` and ``task_name`` are ignored.
-        :param str project_name: The project name of the Tasks to get. To get the experiment
-            in all projects, use the default value of ``None``. (Optional)
+        :param project_name: The project name of the Tasks to get. To get the experiment
+            in all projects, use the default value of ``None``.
             Use a list of strings for multiple optional project names.
-        :param str task_name: The full name or partial name of the Tasks to match within the specified
+        :param task_name: The full name or partial name of the Tasks to match within the specified
             ``project_name`` (or all projects if ``project_name`` is ``None``).
             This method supports regular expressions for name matching (if you wish to match special characters and
-            avoid any regex behaviour, use re.escape()). (Optional)
+            avoid any regex behaviour, use re.escape()).
             To match an exact task name (i.e. not partial matching),
             add ^/$ at the beginning/end of the string, for example: "^exact_task_name_here$"
         :param list tags: Filter based on the requested list of tags (``str``). To exclude a tag add "-" prefix to the
@@ -1574,22 +1569,24 @@ class Task(_Task):
 
             This example means ("a" AND "b" AND "c" AND ("d" OR NOT "e") AND ("f" OR "g")).
             See https://clear.ml/docs/latest/docs/clearml_sdk/task_sdk/#tag-filters for more information.
-        :param bool allow_archived: If ``True`` (default), allow to return archived Tasks. If ``False`` filter out archived Tasks
-        :param dict task_filter: Filter and order Tasks.
+        :param allow_archived: If ``True`` (default), allow to return archived Tasks. If ``False`` filter out archived Tasks.
+        :param task_filter: Filter and order Tasks.
             See :class:`.backend_api.service.v?.tasks.GetAllRequest` for details; the ? needs to be replaced by the appropriate version.
 
           - ``parent`` (``str``) - Filter by parent task-id matching
           - ``search_text`` (``str``) - Free text search (in task fields comment/name/id)
           - ``status`` (``List[str]``) - List of valid statuses. Options are: "created", "queued", "in_progress", "stopped", "published", "publishing", "closed", "failed", "completed", "unknown"
-          - ``type`` (``List[str]``) - List of valid task types. Options are: 'training', 'testing', 'inference', 'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc'. 'custom'
+          - ``type`` (``List[str]``) - List of valid task types. Options are: 'training', 'testing', 'inference', 'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc', 'custom'
           - ``user`` (``List[str]``) - Filter based on Task's user owner, provide list of valid user IDs.
-          - ``order_by`` (``List[str]``) - List of field names to order by. When ``search_text`` is used. Use '-' prefix to specify descending order. Optional, recommended when using page. Example: ``order_by=['-last_update']``
+          - ``order_by`` (``List[str]``) - List of field names to order by. When ``search_text`` is used, ``'@text_score'``
+            can be used as a field representing the text score of returned Tasks. Use '-' prefix to specify descending
+            order. Recommended when paginating results (via the ``page``/``page_size`` fields), to ensure a consistent
+            order across pages. Example: ``order_by=['-last_update']``
           - ``_all_`` (``dict(fields=[], pattern='')``) - Match string ``pattern`` (regular expression) appearing in All ``fields``. Example: ``dict(fields=['script.repository'], pattern='github.com/user')``
           - ``_any_`` (``dict(fields=[], pattern='')``) - Match string ``pattern`` (regular expression) appearing in any of the ``fields``. Example: ``dict(fields=['comment', 'name'], pattern='my comment')``
           - Examples: ``{'status': ['stopped'], 'order_by': ["-last_update"]}`` , ``{'order_by'=['-last_update'], '_all_'=dict(fields=['script.repository'], pattern='github.com/user'))``
 
         :return: The Tasks specified by the parameter combinations (see the parameters).
-        :rtype: List[Task]
         """
         task_filter = task_filter or {}
         if not allow_archived:
@@ -1620,17 +1617,13 @@ class Task(_Task):
         Notice, if ``additional_return_fields`` is specified, returns a list of
         dictionaries with requested fields (dict per Task)
 
-        :param str project_name: The project name of the Tasks to get. To get the experiment
-            in all projects, use the default value of ``None``. (Optional)
+        :param project_name: The project name of the Tasks to get. To get the experiment
+            in all projects, use the default value of ``None``.
             Use a list of strings for multiple optional project names.
-        :param str task_name: The full name or partial name of the Tasks to match within the specified
+        :param task_name: The full name or partial name of the Tasks to match within the specified
             ``project_name`` (or all projects if ``project_name`` is ``None``).
             This method supports regular expressions for name matching (if you wish to match special characters and
-            avoid any regex behaviour, use re.escape()). (Optional)
-        :param str project_name: project name (``str``) the task belongs to (use ``None`` for all projects)
-        :param str task_name: task name (``str``) within the selected project
-            Return any partial match of task_name, regular expressions matching is also supported.
-            If ``None`` is passed, returns all tasks within the project
+            avoid any regex behaviour, use re.escape()).
         :param list tags: Filter based on the requested list of tags (``str``).
             To exclude a tag add "-" prefix to the tag. Example: ``["best", "-debug"]``.
             The default behaviour is to join all tags with a logical "OR" operator.
@@ -1656,24 +1649,28 @@ class Task(_Task):
 
             This example means ("a" AND "b" AND "c" AND ("d" OR NOT "e") AND ("f" OR "g")).
             See https://clear.ml/docs/latest/docs/clearml_sdk/task_sdk/#tag-filters for more information.
-        :param list additional_return_fields: Optional, if not provided return a list of Task IDs.
-            If provided return dict per Task with the additional requested fields.
+        :param list additional_return_fields: If not provided, return a list of Task IDs.
+            If provided, return a dict per Task with the additional requested fields.
             Example: ``returned_fields=['last_updated', 'user', 'script.repository']`` will return a list of dict:
             ``[{'id': 'task_id', 'last_update': datetime.datetime(), 'user': 'user_id', 'script.repository': 'https://github.com/user/'}, ]``
-        :param dict task_filter: filter and order Tasks.
+        :param task_filter: Filter and order Tasks.
             See :class:`.backend_api.service.v?.tasks.GetAllRequest` for details; the ? needs to be replaced by the appropriate version.
 
           - ``parent`` (``str``) - Filter by parent task-id matching
           - ``search_text`` (``str``) - Free text search (in task fields comment/name/id)
           - ``status`` (``List[str]``) - List of valid statuses. Options are: "created", "queued", "in_progress", "stopped", "published", "publishing", "closed", "failed", "completed", "unknown"
-          - ``type`` (``List[Union[str, TaskTypes]]``) - List of valid task types. Options are: 'training', 'testing', 'inference', 'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc'. 'custom'
+          - ``type`` (``List[Union[str, TaskTypes]]``) - List of valid task types. Options are: 'training', 'testing', 'inference', 'data_processing', 'application', 'monitor', 'controller', 'optimizer', 'service', 'qc', 'custom'
           - ``user`` (``List[str]``) - Filter based on Task's user owner, provide list of valid user IDs.
-          - ``order_by`` (``List[str]``) - List of field names to order by. When ``search_text`` is used. Use '-' prefix to specify descending order. Optional, recommended when using page. Example: ``order_by=['-last_update']``
+          - ``order_by`` (``List[str]``) - List of field names to order by. When ``search_text`` is used, ``'@text_score'``
+            can be used as a field representing the text score of returned Tasks. Use '-' prefix to specify descending
+            order. Recommended when paginating results (via the ``page``/``page_size`` fields), to ensure a consistent
+            order across pages. Example: ``order_by=['-last_update']``
           - ``_all_`` (``dict(fields=[], pattern='')``) - Match string ``pattern`` (regular expression) appearing in All ``fields``. Example: ``dict(fields=['script.repository'], pattern='github.com/user')``
           - ``_any_`` (``dict(fields=[], pattern='')``) - Match string ``pattern`` (regular expression) appearing in any of the ``fields``. Example: ``dict(fields=['comment', 'name'], pattern='my comment')``
           - Examples: ``{'status': ['stopped'], 'order_by': ["-last_update"]}`` , ``{'order_by'=['-last_update'], '_all_'=dict(fields=['script.repository'], pattern='github.com/user'))``
 
-        :return: The Tasks specified by the parameter combinations (see the parameters).
+        :return: A list of Task IDs matching the parameter combinations (see the parameters), or, if
+            ``additional_return_fields`` is specified, a list of dicts with the requested fields (one dict per Task).
         """
         task_filter = task_filter or {}
         if tags:
@@ -1722,8 +1719,8 @@ class Task(_Task):
         """
         Set the storage / output URL for this task. This is the default location for output models and other artifacts.
 
-        :param str/bool value: The value to set for output URI. Can be either a bucket link, ``True`` for default server
-            or Fal``se. Check ``Task.init`` reference docs for more info (output_uri is a parameter).
+        :param value: The value to set for output URI. Can be either a bucket link, ``True`` for default server,
+            or ``False``. Check ``Task.init`` reference docs for more info (output_uri is a parameter).
         """
 
         # check if this is boolean
@@ -1811,7 +1808,7 @@ class Task(_Task):
         source_task: Optional[Union["Task", str]] = None,
         name: Optional[str] = None,
         comment: Optional[str] = None,
-        parent: Optional[str] = None,
+        parent: Optional[Union["Task", str]] = None,
         project: Optional[str] = None,
     ) -> TaskInstance:
         """
@@ -1820,19 +1817,18 @@ class Task(_Task):
 
         Use this method to manage experiments and for autoML.
 
-        :param str source_task: The Task to clone. Specify a Task object or a  Task ID. (Optional)
-        :param str name: The name of the new cloned Task. (Optional)
-        :param str comment: A comment / description for the new cloned Task. (Optional)
-        :param str parent: The ID of the parent Task of the new Task.
+        :param source_task: The Task to clone. Specify a Task object or a Task ID.
+        :param name: The name of the new cloned Task.
+        :param comment: A comment / description for the new cloned Task.
+        :param parent: The parent Task of the new Task. Specify a Task object or a Task ID.
 
           - If ``parent`` is not specified, then ``parent`` is set to ``source_task.parent``.
           - If ``parent`` is not specified and ``source_task.parent`` is not available, then ``parent`` set to ``source_task``.
 
-        :param str project: The ID of the project in which to create the new Task.
-            If ``None``, the new task inherits the original Task's project. (Optional)
+        :param project: The ID of the project in which to create the new Task.
+            If ``None``, the new task inherits the original Task's project.
 
         :return: The new cloned Task (experiment).
-        :rtype: Task
         """
         assert isinstance(source_task, (str, Task))
         if not Session.check_min_api_version("2.4"):
@@ -1873,10 +1869,10 @@ class Task(_Task):
            A worker daemon must be listening at the queue for the worker to fetch the Task and execute it,
            see "ClearML Agent" in the ClearML Documentation.
 
-        :param Task/str task: The Task to enqueue. Specify a Task object or  Task ID.
-        :param str queue_name: The name of the queue. If not specified, then ``queue_id`` must be specified.
-        :param str queue_id: The ID of the queue. If not specified, then ``queue_name`` must be specified.
-        :param bool force: If ``True``, reset the Task if necessary before enqueuing it
+        :param Task/str task: The Task to enqueue. Specify a Task object or Task ID.
+        :param queue_name: The name of the queue. If not specified, then ``queue_id`` must be specified.
+        :param queue_id: The ID of the queue. If not specified, then ``queue_name`` must be specified.
+        :param force: If ``True``, reset the Task if necessary before enqueuing it.
 
         :return: An enqueue JSON response.
 
@@ -1895,7 +1891,7 @@ class Task(_Task):
                         }
                 }
 
-            - ``queued``  - The number of Tasks enqueued (an integer or ``null``).
+            - ``queued`` - The number of Tasks enqueued (an integer or ``null``).
             - ``updated`` - The number of Tasks updated (an integer or ``null``).
             - ``fields``
 
@@ -1951,10 +1947,10 @@ class Task(_Task):
         """
         Get the number of tasks enqueued in a given queue.
 
-        :param queue_name: The name of the queue. If not specified, then ``queue_id`` must be specified
-        :param queue_id: The ID of the queue. If not specified, then ``queue_name`` must be specified
+        :param queue_name: The name of the queue. If not specified, then ``queue_id`` must be specified.
+        :param queue_id: The ID of the queue. If not specified, then ``queue_name`` must be specified.
 
-        :return: The number of tasks enqueued in the given queue
+        :return: The number of tasks enqueued in the given queue.
         """
         if not Session.check_min_api_server_version("2.20", raise_error=True):
             raise ValueError("You version of clearml-server does not support the 'queues.get_num_entries' endpoint")
@@ -1974,36 +1970,35 @@ class Task(_Task):
         """
         Dequeue (remove) a Task from an execution queue.
 
-        :param Task/str task: The Task to dequeue. Specify a Task object or  Task ID.
+        :param Task/str task: The Task to dequeue. Specify a Task object or Task ID.
 
         :return: A dequeue JSON response.
 
-        .. code-block:: javascript
+            .. code-block:: javascript
 
-           {
-                "dequeued": 1,
-                "updated": 1,
-                "fields": {
-                    "status": "created",
-                    "status_reason": "",
-                    "status_message": "",
-                    "status_changed": "2020-02-24T16:43:43.057320+00:00",
-                    "last_update": "2020-02-24T16:43:43.057320+00:00",
-                    "execution.queue": null
-                    }
-            }
+               {
+                    "dequeued": 1,
+                    "updated": 1,
+                    "fields": {
+                        "status": "created",
+                        "status_reason": "",
+                        "status_message": "",
+                        "status_changed": "2020-02-24T16:43:43.057320+00:00",
+                        "last_update": "2020-02-24T16:43:43.057320+00:00",
+                        "execution.queue": null
+                        }
+                }
 
-        - ``dequeued``  - The number of Tasks enqueued (an integer or ``null``).
-        - ``fields``
+            - ``dequeued`` - The number of Tasks dequeued (an integer or ``null``).
+            - ``updated`` - The number of Tasks updated (an integer or ``null``).
+            - ``fields``
 
-          - ``status`` - The status of the experiment.
-          - ``status_reason`` - The reason for the last status change.
-          - ``status_message`` - Information about the status.
-          - ``status_changed`` - The last status change date and time in ISO 8601 format.
-          - ``last_update`` - The last time the Task was created, updated, changed, or events for this task were reported.
-          - ``execution.queue`` - The ID of the queue where the Task is enqueued. ``null`` indicates not enqueued.
-
-        - ``updated`` - The number of Tasks updated (an integer or ``null``).
+              - ``status`` - The status of the experiment.
+              - ``status_reason`` - The reason for the last status change.
+              - ``status_message`` - Information about the status.
+              - ``status_changed`` - The last status change date and time in ISO 8601 format.
+              - ``last_update`` - The last time the Task was created, updated, changed, or events for this task were reported.
+              - ``execution.queue`` - The ID of the queue where the Task is enqueued. ``null`` indicates not enqueued.
 
         """
         assert isinstance(task, (str, Task))
@@ -2021,10 +2016,10 @@ class Task(_Task):
 
     def set_progress(self, progress: int) -> None:
         """
-        Sets Task's progress (0 - 100)
+        Set Task's progress (0 - 100).
         Progress is a field computed and reported by the user.
 
-        :param progress: numeric value (0 - 100)
+        :param progress: Numeric value (0 - 100).
         """
         if not isinstance(progress, int) or progress < 0 or progress > 100:
             self.log.warning(f"Can't set progress {progress} as it is not and int between 0 and 100")
@@ -2033,10 +2028,10 @@ class Task(_Task):
 
     def get_progress(self) -> Optional[int]:
         """
-        Gets Task's progress (0 - 100)
+        Get Task's progress (0 - 100).
 
         :return: Task's progress as an int.
-            In case the progress doesn't exist, ``None`` will be returned
+            In case the progress doesn't exist, ``None`` will be returned.
         """
         progress = self._get_runtime_properties().get("progress")
         if progress is None or not progress.isnumeric():
@@ -2066,9 +2061,9 @@ class Task(_Task):
     def remove_tags(self, tags: Union[Sequence[str], str]):
         """
         Remove Tags from this task. Old tags that aren't specified are not deleted. When executing a Task (experiment) remotely,
-        this method has no effect).
+        this method has no effect.
 
-        :param tags: A list of tags to add to the Task.
+        :param tags: A list of tags to remove from the Task.
         """
         tags_to_remove = (
             tags.split(" ")
@@ -2096,7 +2091,7 @@ class Task(_Task):
         When running remotely, the value of the connected object is overridden by the corresponding value found
         under the experiment's UI/backend (unless ``ignore_remote_overrides`` is ``True``).
 
-        :param object mutable: The experiment component to connect. The object must be one of the following types:
+        :param mutable: The experiment component to connect. The object must be one of the following types:
 
           - argparse - An argparse object for parameters.
           - dict - A dictionary for parameters. Note: only keys of type ``str`` are supported.
@@ -2105,18 +2100,18 @@ class Task(_Task):
           - type - A Class type, storing all class properties (excluding '_' prefixed properties).
           - object - A class instance, storing all instance properties (excluding '_' prefixed properties).
 
-        :param str name: A section name for the connected object (defaults to 'General').
-            Currently, ``name`` is only supported for ``dict`` and ``TaskParameter`` objects, and should be omitted for the other supported types. (Optional)
+        :param name: A section name for the connected object (defaults to 'General').
+            Currently, ``name`` is only supported for ``dict`` and ``TaskParameter`` objects, and should be omitted for the other supported types.
             For example, by setting ``name='General'`` the connected dictionary will be under the General section in the hyperparameters section.
 
         :param ignore_remote_overrides: If ``True``, ignore UI/backend overrides when running remotely.
             Default is ``False``, meaning that any changes made in the UI/backend will be applied in remote execution.
 
-        :return: Returns the same object passed as ``mutable``, unless the object is a dict.
+        :return: The same object passed as ``mutable``, unless the object is a dict.
                  For dicts ``Task.connect`` will return the dict decorated as a ``ProxyDictPostWrite``.
                  This is done to allow propagating the updates from the connected object.
 
-        :raise: Raises an exception if passed an unsupported object.
+        :raise: If passed an unsupported object, raise an exception.
         """
         # input model connect and task parameters will handle this instead
         if not isinstance(mutable, (InputModel, TaskParameters)):
@@ -2156,13 +2151,13 @@ class Task(_Task):
         Manually specify a list of required packages or a local requirements.txt file. Note that this will
         overwrite all existing packages.
 
-        When running remotely this call is ignored
+        When running remotely this call is ignored.
 
         :param packages: The list of packages or the path to the requirements.txt file.
 
             Example: ``["tqdm==2.1", "scikit-learn"]`` or ``"./requirements.txt"`` or ``""``
             Use an empty string (``packages=""``) to clear the requirements section (remote execution will use
-                requirements.txt from the git repository if the file exists)
+            requirements.txt from the git repository if the file exists).
         """
         if running_remotely() or packages is None:
             return
@@ -2195,14 +2190,14 @@ class Task(_Task):
         Example local repo copy: ``"./repo"`` - will automatically store the remote
         repo URL and commit ID based on the locally cloned copy.
 
-        When executing remotely, this call will not override the repository data (it is ignored)
+        When executing remotely, this call will not override the repository data (it is ignored).
 
-        :param repo: Optional, remote URL for the repository to use, OR path to local copy of the git repository.
+        :param repo: Remote URL for the repository to use, OR path to local copy of the git repository.
             Use an empty string to clear the repo.
-            Example: ``"https://github.com/clearml/clearml.git"`` or ``"~/project/repo"`` or ``""``
-        :param branch: Optional, specify the remote repository branch (Ignored, if local repo path is used).
+            Example: ``"https://github.com/clearml/clearml.git"`` or ``"~/project/repo"`` or ``""``.
+        :param branch: The remote repository branch (Ignored, if local repo path is used).
             Use an empty string to clear the branch.
-        :param commit: Optional, specify the repository commit ID (Ignored, if local repo path is used).
+        :param commit: The repository commit ID (Ignored, if local repo path is used).
             Use an empty string to clear the commit.
         """
         if running_remotely():
@@ -2223,7 +2218,7 @@ class Task(_Task):
 
     def get_requirements(self) -> RequirementsDict:
         """
-        Get the task's requirements
+        Get the task's requirements.
 
         :return: A ``RequirementsDict`` object that holds the ``pip``, ``conda``, ``orig_pip`` requirements.
         """
@@ -2269,16 +2264,16 @@ class Task(_Task):
             A local path must be relative path. When executing a Task remotely in a worker, the contents brought
             from the **ClearML Server** (backend) overwrites the contents of the file.
 
-        :param str name: Configuration section name. default: 'General'.
-            Allows users to store multiple configuration dicts/files
+        :param name: Configuration section name. Default: 'General'.
+            Allows users to store multiple configuration dicts/files.
 
-        :param str description: Configuration section description (text). Default: ``None``
+        :param description: Configuration section description (text). Default: ``None``.
 
-        :param bool ignore_remote_overrides: If ``True``, ignore UI/backend overrides when running remotely.
+        :param ignore_remote_overrides: If ``True``, ignore UI/backend overrides when running remotely.
             Default is ``False``, meaning that any changes made in the UI/backend will be applied in remote execution.
 
-        :return: If a dictionary is specified, then a dictionary is returned. If ``pathlib2.Path`` / ``str`` is
-            specified, then a path to a local configuration file is returned. Configuration object.
+        :return: If a dictionary/list is specified, then a dictionary/list is returned. If ``pathlib2.Path`` / ``str``
+            is specified, then a path to a local configuration file is returned.
         """
         ignore_remote_overrides = self._handle_ignore_remote_overrides(
             (name or "General") + "/_ignore_remote_overrides_config_",
@@ -2466,7 +2461,7 @@ class Task(_Task):
 
         Later, when creating an output model, the model will include the label enumeration dictionary.
 
-        :param dict enumeration: A label enumeration dictionary of string (label) to integer (value) pairs.
+        :param enumeration: A label enumeration dictionary of string (label) to integer (value) pairs.
 
             For example:
 
@@ -2531,14 +2526,16 @@ class Task(_Task):
         A dictionary named ``multi_node_instance`` will be connected to the tasks.
         One can use this dictionary to modify the behaviour of this function when running remotely.
         The contents of this dictionary correspond to the parameters of this function, and they are:
-        - ``total_num_nodes`` - the total number of nodes, including the master node
-        - ``queue`` - the queue to enqueue the nodes to
 
-        The following environment variables, will be set:
-        - ``MASTER_ADDR`` - the address of the machine that the master node is running on
-        - ``MASTER_PORT`` - the open port of the machine that the master node is running on
-        - ``WORLD_SIZE`` - the total number of nodes, including the master
-        - ``RANK`` - the rank of the current node (master has rank 0)
+        - ``total_num_nodes`` - the total number of nodes, including the master node.
+        - ``queue`` - the queue to enqueue the nodes to.
+
+        The following environment variables will be set:
+
+        - ``MASTER_ADDR`` - the address of the machine that the master node is running on.
+        - ``MASTER_PORT`` - the open port of the machine that the master node is running on.
+        - ``WORLD_SIZE`` - the total number of nodes, including the master.
+        - ``RANK`` - the rank of the current node (master has rank 0).
 
         One may use this function in conjunction with PyTorch's distributed communication package.
         Note that ``Task.launch_multi_node`` should be called before ``torch.distributed.init_process_group``.
@@ -2584,15 +2581,15 @@ class Task(_Task):
             ]`
 
         :param total_num_nodes: The total number of nodes to be enqueued, including the master node,
-            which should already be enqueued when running remotely
+            which should already be enqueued when running remotely.
         :param port: Port opened by the master node. If the environment variable ``CLEARML_MULTI_NODE_MASTER_DEF_PORT``
             is set, the value of this parameter will be set to the one defined in ``CLEARML_MULTI_NODE_MASTER_DEF_PORT``.
             If ``CLEARML_MULTI_NODE_MASTER_DEF_PORT`` doesn't exist, but ``MASTER_PORT`` does, then the value of this
             parameter will be set to the one defined in ``MASTER_PORT``. If neither environment variables exist,
-            the value passed to the parameter will be used
+            the value passed to the parameter will be used.
         :param queue: The queue to enqueue the nodes to. Can be different from the queue the master
-            node is enqueued to. If ``None``, the nodes will be enqueued to the same queue as the master node
-        :param wait: If ``True``, the master node will wait for the other nodes to start
+            node is enqueued to. If ``None``, the nodes will be enqueued to the same queue as the master node.
+        :param wait: If ``True``, the master node will wait for the other nodes to start.
         :param addr: The address of the master node's worker. If the environment variable
             ``CLEARML_MULTI_NODE_MASTER_DEF_ADDR`` is set, the value of this parameter will be set to
             the one defined in ``CLEARML_MULTI_NODE_MASTER_DEF_ADDR``.
@@ -2602,16 +2599,16 @@ class Task(_Task):
             the machine the master node is running on will be used.
         :param devices: The devices to use. This can be a positive number indicating the number of devices to use,
             a sequence of indices or the value ``-1`` to indicate all available devices should be used.
-        :param hide_children: If ``True``, the children tasks will be hidden. Otherwise, they will be visible in the UI
+        :param hide_children: If ``True``, the children tasks will be hidden. Otherwise, they will be visible in the UI.
 
         :return: A dictionary containing relevant information regarding the multi node run. This dictionary has the following entries:
 
-          - ``master_addr`` - The address of the machine that the master node is running on
-          - ``master_port`` - The open port of the machine that the master node is running on
-          - ``total_num_nodes`` - The total number of nodes, including the master
-          - ``queue`` - The queue the nodes are enqueued to, excluding the master
-          - ``node_rank`` - The rank of the current node (master has rank 0)
-          - ``wait`` - If ``True``, the master node will wait for the other nodes to start
+          - ``master_addr`` - The address of the machine that the master node is running on.
+          - ``master_port`` - The open port of the machine that the master node is running on.
+          - ``total_num_nodes`` - The total number of nodes, including the master.
+          - ``queue`` - The queue the nodes are enqueued to, excluding the master.
+          - ``node_rank`` - The rank of the current node (master has rank 0).
+          - ``wait`` - If ``True``, the master node will wait for the other nodes to start.
         """
 
         def set_launch_multi_node_runtime_props(task: Task, conf: Dict[str, Any]) -> None:
@@ -2730,9 +2727,9 @@ class Task(_Task):
 
     def mark_started(self, force: bool = False) -> None:
         """
-        Manually mark a Task as started (happens automatically)
+        Manually mark a Task as started (happens automatically).
 
-        :param bool force: If ``True``, the task status will be changed to ``started`` regardless of the current Task state.
+        :param force: If ``True``, the task status will be changed to ``started`` regardless of the current Task state.
         """
         # UI won't let us see metrics if we're not started
         self.started(force=force)
@@ -2740,11 +2737,11 @@ class Task(_Task):
 
     def mark_stopped(self, force: bool = False, status_message: Optional[str] = None) -> None:
         """
-        Manually mark a Task as stopped (also used in :meth:`_at_exit`)
+        Manually mark a Task as stopped (also used in :meth:`_at_exit`).
 
-        :param bool force: If ``True``, the task status will be changed to ``stopped`` regardless of the current Task state.
-        :param str status_message: Optional, add status change message to the stop request.
-            This message will be stored as status_message on the Task's info panel
+        :param force: If ``True``, the task status will be changed to ``stopped`` regardless of the current Task state.
+        :param status_message: Add status change message to the stop request.
+            This message will be stored as status_message on the Task's info panel.
         """
         # flush any outstanding logs
         self.flush(wait_for_uploads=True)
@@ -2753,17 +2750,17 @@ class Task(_Task):
 
     def mark_stop_request(self, force: bool = False, status_message: Optional[str] = None) -> Optional[CallResult]:
         """
-        Request a task to stop. this will not change the task status
+        Request a task to stop. This will not change the task status
         but mark a request for an agent or SDK to actually stop the Task.
         This will trigger the Task's abort callback, and at the end will
-        change the task status to stopped and kill the Task's processes
+        change the task status to stopped and kill the Task's processes.
 
         Notice: calling this on your own Task, will cause
-        the watchdog to call the ``on_abort`` callback and kill the process
+        the watchdog to call the ``on_abort`` callback and kill the process.
 
-        :param bool force: If not ``True``, call fails if the task status is not 'in_progress'
-        :param str status_message: Optional, add status change message to the stop request.
-            This message will be stored as ``status_message`` on the Task's info panel
+        :param force: If not ``True``, call fails if the task status is not 'in_progress'.
+        :param status_message: Add status change message to the stop request.
+            This message will be stored as ``status_message`` on the Task's info panel.
         """
         # flush any outstanding logs
         self.flush(wait_for_uploads=True)
@@ -2774,10 +2771,10 @@ class Task(_Task):
         """
         Flush any outstanding reports or console logs.
 
-        :param bool wait_for_uploads: Wait for all outstanding uploads to complete
+        :param wait_for_uploads: Wait for all outstanding uploads to complete.
 
-            - ``True`` - Wait
-            - ``False`` - Do not wait (default)
+            - ``True`` - Wait.
+            - ``False`` - Do not wait (default).
         """
 
         # make sure model upload is done
@@ -2803,15 +2800,15 @@ class Task(_Task):
         When a worker executes a Task remotely, the Task does not reset unless
         the ``force`` parameter is set to ``True`` (this avoids accidentally clearing logs and metrics).
 
-        :param bool set_started_on_success: If successful, automatically set the Task to ``started``
+        :param set_started_on_success: If successful, automatically set the Task to ``started``.
 
             - ``True`` - If successful, set to started.
             - ``False`` - If successful, do not set to started. (default)
 
-        :param bool force: Force a Task reset, even when executing the Task (experiment) remotely in a worker
+        :param force: Force a Task reset, even when executing the Task (experiment) remotely in a worker.
 
-            - ``True`` - Force
-            - ``False`` - Do not force (default)
+            - ``True`` - Force.
+            - ``False`` - Do not force (default).
         """
         if not running_remotely() or not self.is_main_task() or force:
             super(Task, self).reset(set_started_on_success=set_started_on_success, force=force)
@@ -2886,7 +2883,7 @@ class Task(_Task):
 
         :param delete_artifacts_and_models: If ``True`` (default), artifacts and models would also be deleted.
                                             If callback is provided, this argument is ignored.
-        :param skip_models_used_by_other_tasks: If ``True`` (default), models used by other tasks would not be deleted
+        :param skip_models_used_by_other_tasks: If ``True`` (default), models used by other tasks would not be deleted.
         :param raise_on_error: If ``True``, an exception will be raised when encountering an error.
                                If ``False`` an error would be printed and no exception will be raised.
         :param callback: An optional callback accepting a URI type (``str``) and a URI (``str``) that will be called
@@ -2924,12 +2921,12 @@ class Task(_Task):
            dynamically synchronized with the **ClearML Server** (backend). These static artifacts include
            additional object types. For more information, see ```Task.upload_artifact```.
 
-        :param str name: The name of the artifact.
+        :param name: The name of the artifact.
 
          .. warning::
             If an artifact with the same name was previously registered, it is overwritten.
-        :param object artifact: The artifact object.
-        :param dict metadata: A dictionary of key-value pairs for any metadata. This dictionary appears with the
+        :param artifact: The artifact object.
+        :param metadata: A dictionary of key-value pairs for any metadata. This dictionary appears with the
             experiment in the **ClearML Web-App (UI)**, **ARTIFACTS** tab.
         :param uniqueness_columns: A Sequence of columns for artifact uniqueness comparison criteria, or the default
             value of ``True``. If ``True``, the artifact uniqueness comparison criteria is all the columns,
@@ -3002,10 +2999,10 @@ class Task(_Task):
             .. warning::
                If an artifact with the same name was previously uploaded, then it is overwritten.
 
-        :param artifact_object:  The artifact object.
+        :param artifact_object: The artifact object.
         :param metadata: A dictionary of key-value pairs for any metadata. This dictionary appears with the
             experiment in the **ClearML Web-App (UI)**, **ARTIFACTS** tab.
-        :param bool delete_after_upload: After the upload, delete the local copy of the artifact
+        :param delete_after_upload: After the upload, delete the local copy of the artifact.
 
             - ``True`` - Delete the local copy of the artifact.
             - ``False`` - Do not delete. (default)
@@ -3015,10 +3012,10 @@ class Task(_Task):
             the ``artifact_object`` will be pickled and uploaded as pickle file artifact (with file extension ``.pkl``).
             If set to ``None`` (default), the ``sdk.development.artifacts.auto_pickle`` configuration value will be used.
 
-        :param preview: The artifact preview
+        :param preview: The artifact preview.
 
-        :param wait_on_upload: Whether the upload should be synchronous, forcing the upload to complete
-            before continuing.
+        :param wait_on_upload: If ``True``, the upload is synchronous, forcing the upload to complete
+            before continuing. If ``False`` (default), the upload happens in the background.
 
         :param extension_name: File extension which indicates the format the artifact should be stored as.
             The following are supported, depending on the artifact type (default value applies when ``extension_name`` is ``None``):
@@ -3037,7 +3034,7 @@ class Task(_Task):
             (e.g. ``pandas.DataFrame.to_csv``), even if possible. To deserialize this artifact when getting
             it using the ``Artifact.get`` method, use its ``deserialization_function`` argument.
 
-        :param retries: Number of retries before failing to upload artifact. If 0, the upload is not retried
+        :param retries: Number of retries before failing to upload artifact. If 0, the upload is not retried.
 
         :param sort_keys: If ``True`` (default), sort the keys of the artifact if it is yaml/json serializable.
             Otherwise, don't sort the keys. Ignored if the artifact is not yaml/json serializable.
@@ -3078,10 +3075,12 @@ class Task(_Task):
 
     def get_debug_samples(self, title: str, series: str, n_last_iterations: Optional[int] = None) -> List[dict]:
         """
-        :param str title: Debug sample's title, also called metric in the UI
-        :param str series: Debug sample's series,
-            corresponding to debug sample's file name in the UI, also known as variant
-        :param int n_last_iterations: How many debug sample iterations to fetch in reverse chronological order.
+        Get the Task's debug samples (images), for a specific metric (title) and variant (series).
+
+        :param title: Debug sample's title, also called metric in the UI.
+        :param series: Debug sample's series,
+            corresponding to debug sample's file name in the UI, also known as variant.
+        :param n_last_iterations: How many debug sample iterations to fetch in reverse chronological order.
             Leave empty to get all debug samples.
 
         :raise: TypeError if ``n_last_iterations`` is explicitly set to anything other than a positive integer value
@@ -3140,7 +3139,7 @@ class Task(_Task):
 
     def get_models(self) -> Mapping[str, Sequence[Model]]:
         """
-        Return a dictionary with ``{'input': [], 'output': []}`` loaded/stored models of the current Task
+        Return a dictionary with ``{'input': [], 'output': []}`` loaded/stored models of the current Task.
         Input models are files loaded in the task, either manually or automatically logged.
         Output models are files stored in the task, either manually or automatically logged.
         Automatically logged frameworks include: TensorFlow, Keras, PyTorch, ScikitLearn(joblib) etc.
@@ -3160,13 +3159,12 @@ class Task(_Task):
 
     def is_current_task(self) -> bool:
         """
+        Is this Task object the main execution Task (initially returned by :meth:`Task.init`).
 
         .. note::
             This method is deprecated, use ```Task.is_main_task``` instead.
 
-        Is this Task object the main execution Task (initially returned by :meth:`Task.init`)
-
-        :return: Is this Task object the main execution Task
+        :return: Is this Task object the main execution Task.
 
             - ``True`` - Is the main execution Task.
             - ``False`` - Is not the main execution Task.
@@ -3176,7 +3174,7 @@ class Task(_Task):
 
     def is_main_task(self) -> bool:
         """
-        Is this Task object the main execution Task (initially returned by :meth:`Task.init`)
+        Is this Task object the main execution Task (initially returned by :meth:`Task.init`).
 
         .. note::
            If ```Task.init``` was never called, this method will *not* create
@@ -3186,7 +3184,7 @@ class Task(_Task):
            Task.init() == task
            ```
 
-        :return: Is this Task object the main execution Task
+        :return: Is this Task object the main execution Task.
 
             - ``True`` - Is the main execution Task.
             - ``False`` - Is not the main execution Task.
@@ -3201,30 +3199,31 @@ class Task(_Task):
     ) -> None:
         """
         .. note::
-            This method is deprecated, use ```Task.connect_configuration```  instead.
+            This method is deprecated, use ```Task.connect_configuration``` instead.
         """
         self._set_model_config(config_text=config_text, config_dict=config_dict)
 
     def get_model_config_text(self) -> str:
         """
         .. note::
-            This method is deprecated, use ```Task.connect_configuration```  instead.
+            This method is deprecated, use ```Task.connect_configuration``` instead.
         """
         return self._get_model_config_text()
 
     def get_model_config_dict(self) -> Dict:
         """
         .. note::
-            This method is deprecated, use ```Task.connect_configuration```  instead.
+            This method is deprecated, use ```Task.connect_configuration``` instead.
         """
         return self._get_model_config_dict()
 
-    def set_model_label_enumeration(self, enumeration: Optional[Mapping[str, int]] = None) -> None:
+    def set_model_label_enumeration(self, enumeration: Optional[Dict[str, int]] = None) -> None:
         """
         Set the label enumeration for the Task object before creating an output model.
         Later, when creating an output model, the model will inherit these properties.
 
-        :param dict enumeration: A label enumeration dictionary of string (label) to integer (value) pairs.
+        :param enumeration: A label enumeration dictionary of string (label) to integer (value) pairs. Must be a
+            ``dict`` (not just any ``Mapping``).
 
             For example:
 
@@ -3255,9 +3254,9 @@ class Task(_Task):
 
     def set_initial_iteration(self, offset: int = 0) -> int:
         """
-        Set initial iteration, instead of zero. Useful when continuing training from previous checkpoints
+        Set initial iteration, instead of zero. Useful when continuing training from previous checkpoints.
 
-        :param int offset: Initial iteration (at starting point)
+        :param offset: Initial iteration (at starting point).
         :return: Newly set initial offset.
         """
         return super(Task, self).set_initial_iteration(offset=offset)
@@ -3310,8 +3309,9 @@ class Task(_Task):
            If ```cast``` is ```False``` (default), the values are not parsed. They are returned as is.
 
         :param cast: If ``True``, cast the parameter to the original type. Default ``False``,
-            values are returned in their string representation
+            values are returned in their string representation.
 
+        :return: The Task parameters as a nested dictionary.
         """
         return naive_nested_from_flat_dictionary(self.get_parameters(cast=cast))
 
@@ -3320,6 +3320,8 @@ class Task(_Task):
         Set the parameters for the Task object from a dictionary. The dictionary can be nested.
         This does not link the dictionary to the Task object. It does a one-time update. This
         is the same behavior as the ``Task.connect`` method.
+
+        :param dictionary: The parameters dictionary. Can be nested.
         """
         self._arguments.copy_from_dict(flatten_dictionary(dictionary))
 
@@ -3366,7 +3368,7 @@ class Task(_Task):
 
         :param iterables: Properties iterables, each can be:
 
-            * A dictionary of string key (name) to either a string value (value) or a dict (property details). If the value
+            - A dictionary of string key (name) to either a string value (value) or a dict (property details). If the value
                 is a dict, it must contain a "value" field. For example:
 
                 .. code-block:: javascript
@@ -3378,7 +3380,7 @@ class Task(_Task):
                     }
 
 
-            * An iterable of dicts (each representing property details). Each dict must contain a "name" field and a
+            - An iterable of dicts (each representing property details). Each dict must contain a "name" field and a
                 "value" field. For example:
 
                 .. code-block:: javascript
@@ -3411,6 +3413,7 @@ class Task(_Task):
                       }
                   }
 
+        :return: ``True`` if the properties were set successfully.
         """
         if not Session.check_min_api_version("2.9"):
             self.log.info("User properties are not supported by the server")
@@ -3431,15 +3434,14 @@ class Task(_Task):
 
         :return: Dictionary with script properties. For example:
 
-        .. code-block:: javascript
+            .. code-block:: javascript
 
-           {
-                'working_dir': 'examples/reporting',
-                'entry_point': 'artifacts.py',
-                'branch': 'master',
-                'repository': 'https://github.com/allegroai/clearml.git'
-           }
-
+               {
+                    'working_dir': 'examples/reporting',
+                    'entry_point': 'artifacts.py',
+                    'branch': 'master',
+                    'repository': 'https://github.com/clearml/clearml.git'
+               }
         """
         script = self.data.script
         return {
@@ -3467,20 +3469,19 @@ class Task(_Task):
         .. code-block:: py
 
             task.set_script(
-                repository='https://github.com/allegroai/clearml.git,
+                repository='https://github.com/clearml/clearml.git',
                 branch='main',
                 working_dir='examples/reporting',
                 entry_point='artifacts.py'
             )
 
-        :param repository: Optional, URL of remote repository. use empty string (``""``) to clear repository entry.
-        :param branch: Optional, Select specific repository branch / tag. use empty string (``""``) to clear branch entry.
-        :param commit: Optional, set specific git commit id. use empty string (``""``) to clear commit ID entry.
-        :param diff: Optional, set "git diff" section. use empty string (``""``) to clear git-diff entry.
-        :param working_dir: Optional, Working directory to launch the script from.
-        :param entry_point: Optional, Path to execute within the repository.
-        :param binary: Optional, binary used to launch the entry point
-
+        :param repository: URL of remote repository. Use empty string (``""``) to clear repository entry.
+        :param branch: Select specific repository branch / tag. Use empty string (``""``) to clear branch entry.
+        :param commit: Set specific git commit id. Use empty string (``""``) to clear commit ID entry.
+        :param diff: Set "git diff" section. Use empty string (``""``) to clear git-diff entry.
+        :param working_dir: Working directory to launch the script from.
+        :param entry_point: Path to execute within the repository.
+        :param binary: Binary used to launch the entry point.
         """
         self.reload()
         script = self.data.script
@@ -3509,8 +3510,10 @@ class Task(_Task):
 
         :param iterables: One or more iterables, each identifying a hyperparameter to delete. Each entry can be either:
 
-            * A dictionary with 'section' and 'name' keys
-            * An iterable (e.g. tuple, list etc.) whose first two items denote 'section' and 'name'
+            - A dictionary with 'section' and 'name' keys.
+            - An iterable (e.g. tuple, list etc.) whose first two items denote 'section' and 'name'.
+
+        :return: ``True`` if the properties were deleted successfully.
         """
         if not Session.check_min_api_version("2.9"):
             self.log.info("User properties are not supported by the server")
@@ -3529,14 +3532,14 @@ class Task(_Task):
         Set the base docker image for this experiment.
         If provided, this value will be used by clearml-agent to execute this experiment
         inside the provided docker image.
-        When running remotely the call is ignored
+        When running remotely the call is ignored.
 
         :param docker_cmd: Deprecated! compound docker container image + arguments
             (example: ``'nvidia/cuda:11.1 -e test=1'``). Deprecated, use specific arguments.
-        :param docker_image: docker container image (example: ``'nvidia/cuda:11.1'``)
-        :param docker_arguments: docker execution parameters (example: ``'-e ENV=1'``)
+        :param docker_image: docker container image (example: ``'nvidia/cuda:11.1'``).
+        :param docker_arguments: docker execution parameters (example: ``'-e ENV=1'``).
         :param docker_setup_bash_script: bash script to run at the
-            beginning of the docker before launching the Task itself. Example: ``['apt update', 'apt-get install -y gcc']``
+            beginning of the docker before launching the Task itself. Example: ``['apt update', 'apt-get install -y gcc']``.
         """
         if not self.running_locally() and self.is_main_task():
             return
@@ -3561,13 +3564,13 @@ class Task(_Task):
         Notice! Should be called before ``Task.init``.
 
         :param seconds_from_start: Maximum number of seconds to wait for scalar/plot reporting before defaulting
-            to machine statistics reporting based on seconds from experiment start time
+            to machine statistics reporting based on seconds from experiment start time.
         :param wait_for_first_iteration_to_start_sec: Set the initial time (seconds) to wait for iteration reporting
-            to be used as x-axis for the resource monitoring. If timeout exceeds then reverts to ``seconds_from_start``
+            to be used as x-axis for the resource monitoring. If timeout exceeds then reverts to ``seconds_from_start``.
         :param max_wait_for_first_iteration_to_start_sec: Set the maximum time (seconds) to allow the resource
-            monitoring to revert back to iteration reporting x-axis after starting to report ``seconds_from_start``
+            monitoring to revert back to iteration reporting x-axis after starting to report ``seconds_from_start``.
 
-        :return: ``True`` if success
+        :return: ``True`` if success.
         """
         if ResourceMonitor._resource_monitor_instances:
             getLogger().warning(
@@ -3606,7 +3609,7 @@ class Task(_Task):
 
         :param queue_name: The queue name used for enqueueing the task. If ``None``, this call exits the process
             without enqueuing the task.
-        :param clone: Clone the Task and execute the newly cloned Task
+        :param clone: Clone the Task and execute the newly cloned Task.
             The values are:
 
           - ``True`` - A cloned copy of the Task will be created, and enqueued, instead of this Task.
@@ -3617,7 +3620,8 @@ class Task(_Task):
           - ``True`` - Exit the process (exit(0)). Note: if ``clone==False``, then ``exit_process`` must be ``True``.
           - ``False`` - Do not exit the process.
 
-        :return Task: return the task object of the newly generated remotely executing task
+        :return: The Task object of the newly generated remotely executing task, or ``None`` if this call is a
+            no-op (the Task is already running remotely).
         """
         # do nothing, we are running remotely
         if running_remotely() and self.is_main_task():
@@ -3707,14 +3711,14 @@ class Task(_Task):
         :param func: A function to execute remotely as a single Task.
             On the remote executed Task the entry-point and the environment are copied from this
             calling process, only this function call redirect the execution flow to the called func,
-            alongside the passed arguments
+            alongside the passed arguments.
         :param func_name: A unique identifier of the function. Default the function name without the namespace.
-            For example Class.foo() becomes 'foo'
-        :param task_name: The newly created Task name. Default: the calling Task name + function name
+            For example Class.foo() becomes 'foo'.
+        :param task_name: The newly created Task name. Default: the calling Task name + function name.
         :param kwargs: Name specific arguments for the target function.
-            These arguments will appear under the configuration, "Function" section
+            These arguments will appear under the configuration, "Function" section.
 
-        :return Task: Return the newly created Task or ``None`` if running remotely and execution is skipped
+        :return: The newly created Task or ``None`` if running remotely and execution is skipped.
         """
         if not self.is_main_task():
             raise ValueError("Only the main Task object can call create_function_task()")
@@ -3797,7 +3801,7 @@ class Task(_Task):
         """
         Wait for a task to reach a defined status.
 
-        :param status: Status to wait for. Defaults to ('completed', 'stopped', 'closed', )
+        :param status: Status to wait for. Defaults to ('completed', 'stopped', 'closed', ).
         :param raise_on_status: Raise RuntimeError if the status of the tasks matches one of these values.
             Defaults to ('failed').
         :param check_interval_sec: Interval in seconds between two checks. Defaults to 60 seconds.
@@ -3819,7 +3823,7 @@ class Task(_Task):
         Export Task's configuration into a dictionary (for serialization purposes).
         A Task can be copied/modified by calling ``Task.import_task()``.
         Notice: Export task does not include the tasks outputs, such as results
-        (scalar/plots etc.) or Task artifacts/models
+        (scalar/plots etc.) or Task artifacts/models.
 
         :return: dictionary of the Task's configuration.
         """
@@ -3841,18 +3845,18 @@ class Task(_Task):
         Update current task with configuration found on the ``task_data`` dictionary.
         See also ``export_task()`` for retrieving Task configuration.
 
-        :param task_data: dictionary with full Task configuration
-        :return: ``True`` if Task update was successful
+        :param task_data: dictionary with full Task configuration.
+        :return: ``True`` if Task update was successful.
         """
         return bool(self.import_task(task_data=task_data, target_task=self, update=True))
 
     def rename(self, new_name: str) -> bool:
         """
-        Rename this task
+        Rename this task.
 
-        :param new_name: The new name of this task
+        :param new_name: The new name of this task.
 
-        :return: ``True`` if the rename was successful and ``False`` otherwise
+        :return: ``True`` if the rename was successful and ``False`` otherwise.
         """
         result = bool(self._edit(name=new_name))
         self.reload()
@@ -3865,7 +3869,7 @@ class Task(_Task):
         system_tags: Optional[Sequence[str]] = None,
     ) -> bool:
         """
-        Move this task to another project
+        Move this task to another project.
 
         :param new_project_id: The ID of the project the task should be moved to.
             Not required if ``new_project_name`` is passed.
@@ -3873,7 +3877,7 @@ class Task(_Task):
             Not required if ``new_project_id`` is passed.
         :param system_tags: System tags for the project the task should be moved to.
 
-        :return: ``True`` if the move was successful and ``False`` otherwise
+        :return: ``True`` if the move was successful and ``False`` otherwise.
         """
         new_project_id = get_or_create_project(
             self.session,
@@ -3893,17 +3897,17 @@ class Task(_Task):
         """
         Register a Task abort callback (single callback function support only).
         Pass a function to be called from a background thread when the Task is **externally** being aborted.
-        Users must specify a timeout for the callback function execution (default 30 seconds)
-        if the callback execution function exceeds the timeout, the Task's process will be terminated
+        Users must specify a timeout for the callback function execution (default 30 seconds).
+        If the callback execution function exceeds the timeout, the Task's process will be terminated.
 
         Call this register function from the main process only.
 
-        Note: Ctrl-C is Not considered external, only backend induced abort is covered here
+        Note: Ctrl-C is Not considered external, only backend induced abort is covered here.
 
         :param callback_function: Callback function to be called via external thread (from the main process).
-            pass ``None`` to remove existing callback
+            Pass ``None`` to remove existing callback.
         :param callback_execution_timeout: Maximum callback execution time in seconds, after which the process
-            will be terminated even if the callback did not return
+            will be terminated even if the callback did not return.
         """
         if self.__is_subprocess():
             raise ValueError("Register abort callback must be called from the main process, this is a subprocess.")
@@ -3941,10 +3945,10 @@ class Task(_Task):
         Import (create) Task from previously exported Task configuration (see ``Task.export_task``).
         Can also be used to edit/update an existing Task (by passing ``target_task`` and ``update=True``).
 
-        :param task_data: dictionary of a Task's configuration
+        :param task_data: dictionary of a Task's configuration.
         :param target_task: Import ``task_data`` into an existing Task. Can be either ``task_id`` (``str``) or Task object.
         :param update: If ``True``, merge ``task_data`` with current Task configuration.
-        :return: ``True`` if Task was imported/updated
+        :return: The imported/updated Task, or ``None`` if the operation failed.
         """
 
         # restore original API version (otherwise, we might not be able to restore the data correctly)
@@ -3990,7 +3994,7 @@ class Task(_Task):
     @classmethod
     def set_offline(cls, offline_mode: bool = False) -> None:
         """
-        Set offline mode, where all data and logs are stored into local folder, for later transmission
+        Set offline mode, where all data and logs are stored into local folder, for later transmission.
 
         .. note::
             ```Task.set_offline``` can't move the same task from offline to online, nor can it be applied before ```Task.create```.
@@ -4045,9 +4049,9 @@ class Task(_Task):
     @classmethod
     def is_offline(cls) -> bool:
         """
-        Return offline-mode state, If in offline-mode, no communication to the backend is enabled.
+        Return offline-mode state. If in offline-mode, no communication to the backend is enabled.
 
-        :return: boolean offline-mode state
+        :return: Offline-mode state.
         """
         return cls._offline_mode
 
@@ -4068,7 +4072,7 @@ class Task(_Task):
         :param iteration_offset: Reporting of the offline session will be offset with the
             number specified by this parameter. Useful for avoiding overwriting metrics.
 
-        :return: Newly created task ID or the ID of the continued task (``previous_task_id``)
+        :return: Newly created task ID or the ID of the continued task (``previous_task_id``).
         """
         print(f"ClearML: Importing offline session from {session_folder_zip}")
 
@@ -4186,16 +4190,16 @@ class Task(_Task):
 
             Task.set_credentials(
                 api_host='http://localhost:8008', web_host='http://localhost:8080', files_host='http://localhost:8081',
-                key='optional_credentials',  secret='optional_credentials'
+                key='optional_credentials', secret='optional_credentials'
             )
             task = Task.init('project name', 'experiment name')
 
-        :param str api_host: The API server URL. For example, ``host='http://localhost:8008'``
-        :param str web_host: The Web server URL. For example, ``host='http://localhost:8080'``
-        :param str files_host: The file server URL. For example, ``host='http://localhost:8081'``
-        :param str key: The user key (in the key/secret pair). For example, ``key='thisisakey123'``
-        :param str secret: The user secret (in the key/secret pair). For example, ``secret='thisisseceret123'``
-        :param bool store_conf_file: If ``True``, store the current configuration into the ~/clearml.conf file.
+        :param api_host: The API server URL. For example, ``api_host='http://localhost:8008'``.
+        :param web_host: The Web server URL. For example, ``web_host='http://localhost:8080'``.
+        :param files_host: The file server URL. For example, ``files_host='http://localhost:8081'``.
+        :param key: The user key (in the key/secret pair). For example, ``key='thisisakey123'``.
+        :param secret: The user secret (in the key/secret pair). For example, ``secret='thisisseceret123'``.
+        :param store_conf_file: If ``True``, store the current configuration into the ~/clearml.conf file.
             If the configuration file exists, no change will be made (outputs a warning).
             Not applicable when running remotely (i.e. clearml-agent).
         """
@@ -4251,7 +4255,7 @@ class Task(_Task):
         Use with care.
 
         :param task_id: Task ID to simulate, notice that all configuration will be taken from the specified
-            Task, regardless of the code initial values, just like it as if executed by ClearML agent
+            Task, regardless of the code initial values, just like it as if executed by ClearML agent.
         :param reset_task: If ``True``, target Task, is automatically cleared / reset.
         """
 
@@ -4278,10 +4282,10 @@ class Task(_Task):
         """
         Get the queue the task was executed on.
 
-        :param return_name: If ``True``, return the name of the queue. Otherwise, return its ID
+        :param return_name: If ``True``, return the name of the queue. Otherwise, return its ID.
 
-        :return: Return the ID or name of the queue the task was executed on.
-            If no queue was found, return ``None``
+        :return: The ID or name of the queue the task was executed on.
+            If no queue was found, return ``None``.
         """
         queue_id = self.data.execution.queue
         if not return_name or not queue_id:


### PR DESCRIPTION
## Related Issue \ discussion
See #1565 .

## Patch Description
We're dropping Python 2-related usage of the `six.python_2_unicode_compatible` decorator.